### PR TITLE
URL Cleanup

### DIFF
--- a/collection-plugins/akka/pom.xml
+++ b/collection-plugins/akka/pom.xml
@@ -17,7 +17,7 @@
     <repositories>
         <repository>
             <id>typesafe</id>
-            <url>http://repo.typesafe.com/typesafe/releases/</url>
+            <url>https://repo.typesafe.com/typesafe/releases/</url>
         </repository>
     </repositories>
 

--- a/collection-plugins/axon/pom.xml
+++ b/collection-plugins/axon/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>insight-plugin-axon</artifactId>
     <name>com.springsource.insight.plugins:axon</name>
     <packaging>jar</packaging>
-    <url>http://www.axonframework.org</url>
+    <url>https://axoniq.io</url>
 
     <parent>
         <groupId>com.springsource.insight</groupId>

--- a/collection-plugins/eclipse-persistence/pom.xml
+++ b/collection-plugins/eclipse-persistence/pom.xml
@@ -25,7 +25,7 @@
         <repository>
             <id>EclipseLink-Repo</id>
             <name>EclipseLink repo</name>
-            <url>http://download.eclipse.org/rt/eclipselink/maven.repo</url>
+            <url>https://download.eclipse.org/rt/eclipselink/maven.repo</url>
         </repository>
     </repositories>
 

--- a/collection-plugins/spring-neo4j/pom.xml
+++ b/collection-plugins/spring-neo4j/pom.xml
@@ -21,7 +21,7 @@
     <repositories>
         <repository>
             <id>neo4j-releases</id>
-            <url>http://m2.neo4j.org/content/repositories/releases</url>
+            <url>https://m2.neo4j.org/content/repositories/releases</url>
         </repository>
     </repositories>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -262,14 +262,14 @@
 
     <organization>
         <name>VMware, Inc.</name>
-        <url>http://springsource.org/insight</url>
+        <url>https://www.spring.io</url>
     </organization>
 
     <repositories>
         <repository>
             <id>maven.springframework.org</id>
             <name>SpringSource snapshots</name>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -277,7 +277,7 @@
         <repository>    <!-- NOTE: these values must match the properties -->
             <id>spring-release</id>
             <name>Spring Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -288,7 +288,7 @@
         <repository>    <!-- NOTE: these values must match the properties -->
             <id>spring-milestone</id>
             <name>Spring Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -321,7 +321,7 @@
         <repository>
             <id>org.jboss.maven.release.nexus</id>
             <name>JBoss Maven Central-compatible Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -332,7 +332,7 @@
         <repository>
             <id>org.jboss.maven.release</id>
             <name>JBoss Maven Central-compatible Repository</name>
-            <url>http://repository.jboss.com/maven2</url>
+            <url>http://repository.jboss.com/maven2/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -359,7 +359,7 @@
         <pluginRepository>    <!-- NOTE: these values must match the properties -->
             <id>spring-release</id>
             <name>Spring Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -371,7 +371,7 @@
         <pluginRepository>    <!-- NOTE: these values must match the properties -->
             <id>spring-milestone</id>
             <name>Spring Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -382,7 +382,7 @@
         <pluginRepository>
             <id>org.jboss.maven.release.nexus</id>
             <name>JBoss Maven Central-compatible Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -393,7 +393,7 @@
         <pluginRepository>
             <id>maven.springframework.org</id>
             <name>SpringSource snapshots</name>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -1061,7 +1061,7 @@
                         </execution>
                         <execution>
                             <id>compile-test-aspects</id>
-                            <!-- see http://jira.codehaus.org/browse/MASPECTJ-92 workaround -->
+                            <!-- see https://jira.codehaus.org/browse/MASPECTJ-92 workaround -->
                             <phase>process-test-sources</phase>
                             <goals>
                                 <goal>test-compile</goal>
@@ -1171,7 +1171,7 @@
                         <quiet>true</quiet>
                         <links>
                             <link>http://docs.mockito.googlecode.com/hg/${mockito.version}</link>
-                            <link>http://kentbeck.github.com/junit/javadoc/${junit.version}</link>
+                            <link>https://kentbeck.github.com/junit/javadoc/${junit.version}</link>
                         </links>
                     </configuration>
                 </plugin>
@@ -1266,7 +1266,7 @@
                             <goal>execute</goal>
                         </goals>
                         <configuration>
-                            <!-- see http://maven.apache.org/ref/3.0.4/maven-core/apidocs/org/apache/maven/execution/MavenSession.html -->
+                            <!-- see https://maven.apache.org/ref/3.0.4/maven-core/apidocs/org/apache/maven/execution/MavenSession.html -->
                             <source>
                                 <![CDATA[
 								if (!session.goals.contains("deploy")) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://repository.jboss.com/maven2 (301) migrated to:  
  http://repository.jboss.com/maven2/ ([https](https://repository.jboss.com/maven2) result SSLHandshakeException).
* http://maven.hyperic.org/external (403) migrated to:  
  http://maven.hyperic.org/external ([https](https://maven.hyperic.org/external) result SSLHandshakeException).
* http://private.maven.springsource.com/milestone (403) migrated to:  
  http://private.maven.springsource.com/milestone ([https](https://private.maven.springsource.com/milestone) result SSLHandshakeException).
* http://private.maven.springsource.com/release (403) migrated to:  
  http://private.maven.springsource.com/release ([https](https://private.maven.springsource.com/release) result SSLHandshakeException).
* http://private.maven.springsource.com/snapshot (403) migrated to:  
  http://private.maven.springsource.com/snapshot ([https](https://private.maven.springsource.com/snapshot) result SSLHandshakeException).
* http://dist.gemstone.com/maven/release (404) migrated to:  
  http://dist.gemstone.com/maven/release ([https](https://dist.gemstone.com/maven/release) result SSLHandshakeException).
* http://docs.mockito.googlecode.com/hg/ (404) migrated to:  
  http://docs.mockito.googlecode.com/hg/ ([https](https://docs.mockito.googlecode.com/hg/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.axonframework.org (301) migrated to:  
  https://axoniq.io ([https](https://www.axonframework.org) result SSLHandshakeException).
* http://springsource.org/insight (302) migrated to:  
  https://www.spring.io ([https](https://springsource.org/insight) result SSLHandshakeException).
* http://jira.codehaus.org/browse/MASPECTJ-92 (UnknownHostException) migrated to:  
  https://jira.codehaus.org/browse/MASPECTJ-92 ([https](https://jira.codehaus.org/browse/MASPECTJ-92) result UnknownHostException).

## Fixed Success 
These URLs were fixed successfully.

* http://maven.apache.org/ref/3.0.4/maven-core/apidocs/org/apache/maven/execution/MavenSession.html migrated to:  
  https://maven.apache.org/ref/3.0.4/maven-core/apidocs/org/apache/maven/execution/MavenSession.html ([https](https://maven.apache.org/ref/3.0.4/maven-core/apidocs/org/apache/maven/execution/MavenSession.html) result 200).
* http://download.eclipse.org/rt/eclipselink/maven.repo migrated to:  
  https://download.eclipse.org/rt/eclipselink/maven.repo ([https](https://download.eclipse.org/rt/eclipselink/maven.repo) result 301).
* http://kentbeck.github.com/junit/javadoc/ migrated to:  
  https://kentbeck.github.com/junit/javadoc/ ([https](https://kentbeck.github.com/junit/javadoc/) result 301).
* http://m2.neo4j.org/content/repositories/releases migrated to:  
  https://m2.neo4j.org/content/repositories/releases ([https](https://m2.neo4j.org/content/repositories/releases) result 301).
* http://repository.jboss.org/nexus/content/groups/public migrated to:  
  https://repository.jboss.org/nexus/content/groups/public ([https](https://repository.jboss.org/nexus/content/groups/public) result 301).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://maven.springframework.org/snapshot migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* http://repo.typesafe.com/typesafe/releases/ migrated to:  
  https://repo.typesafe.com/typesafe/releases/ ([https](https://repo.typesafe.com/typesafe/releases/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8081/artifactory/libs-releases-local
* http://localhost:8081/artifactory/libs-snapshots-local
* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance