### PR TITLE
URL Cleanup

### DIFF
--- a/collection-plugins/akka/pom.xml
+++ b/collection-plugins/akka/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-akka</artifactId>
@@ -17,7 +17,7 @@
     <repositories>
         <repository>
             <id>typesafe</id>
-            <url>http://repo.typesafe.com/typesafe/releases/</url>
+            <url>https://repo.typesafe.com/typesafe/releases/</url>
         </repository>
     </repositories>
 

--- a/collection-plugins/akka/src/main/resources/META-INF/insight-plugin-akka.xml
+++ b/collection-plugins/akka/src/main/resources/META-INF/insight-plugin-akka.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-						http://www.springframework.org/schema/beans/spring-beans.xsd
+						https://www.springframework.org/schema/beans/spring-beans.xsd
 						http://www.springframework.org/schema/insight-idk 
-						http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+						https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="akka" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/axon/pom.xml
+++ b/collection-plugins/axon/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-axon</artifactId>
     <name>com.springsource.insight.plugins:axon</name>
     <packaging>jar</packaging>
-    <url>http://www.axonframework.org</url>
+    <url>https://axoniq.io</url>
 
     <parent>
         <groupId>com.springsource.insight</groupId>

--- a/collection-plugins/axon/src/main/resources/META-INF/insight-plugin-axon.xml
+++ b/collection-plugins/axon/src/main/resources/META-INF/insight-plugin-axon.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-    http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="axon" version="${project.version}" publisher="Axon Framework"/>
 

--- a/collection-plugins/cassandra/pom.xml
+++ b/collection-plugins/cassandra/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-cassandra</artifactId>

--- a/collection-plugins/cassandra/src/main/resources/META-INF/insight-plugin-cassandra.xml
+++ b/collection-plugins/cassandra/src/main/resources/META-INF/insight-plugin-cassandra.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="cassandra" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/cassandra12/pom.xml
+++ b/collection-plugins/cassandra12/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-cassandra12</artifactId>

--- a/collection-plugins/cassandra12/src/main/resources/META-INF/insight-plugin-cassandra.xml
+++ b/collection-plugins/cassandra12/src/main/resources/META-INF/insight-plugin-cassandra.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="cassandra12" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/eclipse-persistence/pom.xml
+++ b/collection-plugins/eclipse-persistence/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-eclipse-persistence</artifactId>
@@ -25,7 +25,7 @@
         <repository>
             <id>EclipseLink-Repo</id>
             <name>EclipseLink repo</name>
-            <url>http://download.eclipse.org/rt/eclipselink/maven.repo</url>
+            <url>https://download.eclipse.org/rt/eclipselink/maven.repo</url>
         </repository>
     </repositories>
 

--- a/collection-plugins/eclipse-persistence/src/main/resources/META-INF/insight-plugin-eclipse-persistence.xml
+++ b/collection-plugins/eclipse-persistence/src/main/resources/META-INF/insight-plugin-eclipse-persistence.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="eclipse-persistence" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/ehcache/pom.xml
+++ b/collection-plugins/ehcache/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-ehcache</artifactId>

--- a/collection-plugins/ehcache/src/main/resources/META-INF/insight-plugin-ehcache.xml
+++ b/collection-plugins/ehcache/src/main/resources/META-INF/insight-plugin-ehcache.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="ehcache" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/ehcache/src/test/resources/ehcache.xml
+++ b/collection-plugins/ehcache/src/test/resources/ehcache.xml
@@ -315,7 +315,7 @@ used with JMX monitors.
     (Enable for Terracotta clustered operation)
 
     Note: You need to install and run one or more Terracotta servers to use Terracotta clustering.
-    See http://www.terracotta.org/web/display/orgsite/Download.
+    See https://www.terracotta.org/web/display/orgsite/Download.
 
     Specifies a TerracottaConfig which will be used to configure the Terracotta
     runtime for this CacheManager.
@@ -346,7 +346,7 @@ used with JMX monitors.
     <terracottaConfig url="/app/config/tc-config.xml"/>
 
     Example using a URL to a Terracotta configuration file:
-    <terracottaConfig url="http://internal/ehcache/app/tc-config.xml"/>
+    <terracottaConfig url="https://internal/ehcache/app/tc-config.xml"/>
 
     Example using multiple Terracotta server instance URLs (for fault tolerance):
     <terracottaConfig url="host1:9510,host2:9510,host3:9510"/>

--- a/collection-plugins/ejb3/pom.xml
+++ b/collection-plugins/ejb3/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-ejb3</artifactId>

--- a/collection-plugins/ejb3/src/main/resources/META-INF/insight-plugin-ejb3.xml
+++ b/collection-plugins/ejb3/src/main/resources/META-INF/insight-plugin-ejb3.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="ejb3" version="${project.version}" publisher="SpringSource"/>
     <insight:operation-view operation="ejb3" template="com/springsource/insight/plugin/ejb3/ejb3.ftl"/>

--- a/collection-plugins/files-tracker/pom.xml
+++ b/collection-plugins/files-tracker/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-files-tracker</artifactId>

--- a/collection-plugins/files-tracker/src/main/resources/META-INF/insight-plugin-files-tracker.xml
+++ b/collection-plugins/files-tracker/src/main/resources/META-INF/insight-plugin-files-tracker.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="files-tracker" version="${project.version}" publisher="SpringSource"/>
     <insight:operation-view operation="files-tracker"

--- a/collection-plugins/gemfire-light/pom.xml
+++ b/collection-plugins/gemfire-light/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-gemfire-light</artifactId>

--- a/collection-plugins/gemfire-light/src/main/resources/META-INF/insight-plugin-gemfire-light.xml
+++ b/collection-plugins/gemfire-light/src/main/resources/META-INF/insight-plugin-gemfire-light.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-                http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+                http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="gemfire-light" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/gemfire-light/src/test/resources/gemfire.xml
+++ b/collection-plugins/gemfire-light/src/test/resources/gemfire.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cache PUBLIC "-//GemStone Systems, Inc.//GemFire Declarative Caching 6.5//EN"
-        "http://www.gemstone.com/dtd/cache6_5.dtd">
+        "https://www.gemstone.com/dtd/cache6_5.dtd">
 <cache>
     <region name="test"/>
 </cache>

--- a/collection-plugins/gemfire/pom.xml
+++ b/collection-plugins/gemfire/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-gemfire</artifactId>

--- a/collection-plugins/gemfire/src/main/resources/META-INF/insight-plugin-gemfire.xml
+++ b/collection-plugins/gemfire/src/main/resources/META-INF/insight-plugin-gemfire.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-                http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+                http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="gemfire" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/gemfire/src/test/resources/gemfire.xml
+++ b/collection-plugins/gemfire/src/test/resources/gemfire.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE cache PUBLIC "-//GemStone Systems, Inc.//GemFire Declarative Caching 6.5//EN"
-        "http://www.gemstone.com/dtd/cache6_5.dtd">
+        "https://www.gemstone.com/dtd/cache6_5.dtd">
 <cache>
     <region name="test"/>
 </cache>

--- a/collection-plugins/grails/pom.xml
+++ b/collection-plugins/grails/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-grails</artifactId>

--- a/collection-plugins/grails/src/main/resources/META-INF/insight-plugin-grails.xml
+++ b/collection-plugins/grails/src/main/resources/META-INF/insight-plugin-grails.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="grails" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/grails/src/test/resources/META-INF/test-app-context.xml
+++ b/collection-plugins/grails/src/test/resources/META-INF/test-app-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
     <!--
         This Spring application context is only used in testing scnearios to setup the FreeMarker configuration. When

--- a/collection-plugins/hadoop/pom.xml
+++ b/collection-plugins/hadoop/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-hadoop</artifactId>

--- a/collection-plugins/hadoop/src/main/resources/META-INF/insight-plugin-hadoop.xml
+++ b/collection-plugins/hadoop/src/main/resources/META-INF/insight-plugin-hadoop.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="hadoop" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/hibernate/pom.xml
+++ b/collection-plugins/hibernate/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-hibernate</artifactId>

--- a/collection-plugins/hibernate/src/main/resources/META-INF/insight-plugin-hibernate.xml
+++ b/collection-plugins/hibernate/src/main/resources/META-INF/insight-plugin-hibernate.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="hibernate" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/httpclient3/pom.xml
+++ b/collection-plugins/httpclient3/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-apache-httpclient3</artifactId>

--- a/collection-plugins/httpclient3/src/main/resources/META-INF/insight-plugin-apache-httpclient3.xml
+++ b/collection-plugins/httpclient3/src/main/resources/META-INF/insight-plugin-apache-httpclient3.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="apache-httpclient3" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/httpclient4/pom.xml
+++ b/collection-plugins/httpclient4/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-apache-httpclient4</artifactId>

--- a/collection-plugins/httpclient4/src/main/resources/META-INF/insight-plugin-apache-httpclient4.xml
+++ b/collection-plugins/httpclient4/src/main/resources/META-INF/insight-plugin-apache-httpclient4.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="apache-httpclient4" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/jax-rs/pom.xml
+++ b/collection-plugins/jax-rs/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-jax-rs</artifactId>

--- a/collection-plugins/jax-rs/src/main/resources/META-INF/insight-plugin-jax-rs.xml
+++ b/collection-plugins/jax-rs/src/main/resources/META-INF/insight-plugin-jax-rs.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="jax-rs" version="${project.version}" publisher="SpringSource"/>
     <insight:operation-view operation="jax-rs" template="com/springsource/insight/plugin/jaxrs/jax-rs.ftl"/>

--- a/collection-plugins/jcr/pom.xml
+++ b/collection-plugins/jcr/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-jcr</artifactId>

--- a/collection-plugins/jcr/src/main/resources/META-INF/insight-plugin-jcr.xml
+++ b/collection-plugins/jcr/src/main/resources/META-INF/insight-plugin-jcr.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="jcr" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/jcr/src/test/resources/repository.xml
+++ b/collection-plugins/jcr/src/test/resources/repository.xml
@@ -18,7 +18,7 @@
 
 <!DOCTYPE Repository
         PUBLIC "-//The Apache Software Foundation//DTD Jackrabbit 2.0//EN"
-        "http://jackrabbit.apache.org/dtd/repository-2.0.dtd">
+        "https://jackrabbit.apache.org/dtd/repository-2.0.dtd">
 
 <!-- Example Repository Configuration File
      Used by

--- a/collection-plugins/jdbc/pom.xml
+++ b/collection-plugins/jdbc/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-jdbc</artifactId>

--- a/collection-plugins/jdbc/src/main/resources/META-INF/insight-plugin-jdbc.xml
+++ b/collection-plugins/jdbc/src/main/resources/META-INF/insight-plugin-jdbc.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="jdbc" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/jdbc/src/test/resources/jdbc-test-context.xml
+++ b/collection-plugins/jdbc/src/test/resources/jdbc-test-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
     <jdbc:embedded-database id="dataSource">
         <jdbc:script location="classpath:schema.sql"/>
         <jdbc:script location="classpath:testdata.sql"/>

--- a/collection-plugins/jms/pom.xml
+++ b/collection-plugins/jms/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-jms</artifactId>

--- a/collection-plugins/jms/src/main/resources/META-INF/insight-plugin-jms.xml
+++ b/collection-plugins/jms/src/main/resources/META-INF/insight-plugin-jms.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="jms" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/jmx/pom.xml
+++ b/collection-plugins/jmx/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-jmx</artifactId>

--- a/collection-plugins/jmx/src/main/resources/META-INF/insight-plugin-jmx.xml
+++ b/collection-plugins/jmx/src/main/resources/META-INF/insight-plugin-jmx.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="javax-management" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/jmx/src/test/resources/META-INF/jmx-plugin-test-context.xml
+++ b/collection-plugins/jmx/src/test/resources/META-INF/jmx-plugin-test-context.xml
@@ -3,8 +3,8 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:p="http://www.springframework.org/schema/p"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:component-scan base-package="com.springsource.insight.plugin.jmx"/>
 

--- a/collection-plugins/jndi/pom.xml
+++ b/collection-plugins/jndi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-jndi</artifactId>

--- a/collection-plugins/jndi/src/main/resources/META-INF/insight-plugin-jndi.xml
+++ b/collection-plugins/jndi/src/main/resources/META-INF/insight-plugin-jndi.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="javax-naming-jndi" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/jpa/pom.xml
+++ b/collection-plugins/jpa/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-jpa</artifactId>

--- a/collection-plugins/jpa/src/main/resources/META-INF/insight-plugin-jpa.xml
+++ b/collection-plugins/jpa/src/main/resources/META-INF/insight-plugin-jpa.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="jpa" version="${project.version}" publisher="SpringSource"/>
     <bean id="kpaPluginRuntimeDescriptor"

--- a/collection-plugins/jpa/src/test/resources/META-INF/jpaTestContext.xml
+++ b/collection-plugins/jpa/src/test/resources/META-INF/jpaTestContext.xml
@@ -8,17 +8,17 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans 
-           http://www.springframework.org/schema/beans/spring-beans.xsd
+           https://www.springframework.org/schema/beans/spring-beans.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context.xsd
+           https://www.springframework.org/schema/context/spring-context.xsd
            http://www.springframework.org/schema/data/jpa
-           http://www.springframework.org/schema/data/jpa/spring-jpa-1.0.xsd
+           https://www.springframework.org/schema/data/jpa/spring-jpa-1.0.xsd
            http://www.springframework.org/schema/tx 
-           http://www.springframework.org/schema/tx/spring-tx.xsd
+           https://www.springframework.org/schema/tx/spring-tx.xsd
            http://www.springframework.org/schema/jdbc
-           http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+           https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
            http://www.springframework.org/schema/util
-           http://www.springframework.org/schema/util/spring-util.xsd">
+           https://www.springframework.org/schema/util/spring-util.xsd">
 
     <!-- Enabled annotation-based beans definitions -->
     <context:annotation-config/>

--- a/collection-plugins/jpa/src/test/resources/META-INF/persistence.xml
+++ b/collection-plugins/jpa/src/test/resources/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
              version="1.0">
     <persistence-unit name="jpatest" transaction-type="RESOURCE_LOCAL">
         <class>com.springsource.insight.plugin.jpa.TestEntity</class>

--- a/collection-plugins/jta/pom.xml
+++ b/collection-plugins/jta/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-jta</artifactId>

--- a/collection-plugins/jta/src/main/resources/META-INF/insight-plugin-jta.xml
+++ b/collection-plugins/jta/src/main/resources/META-INF/insight-plugin-jta.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="jta" version="${project.version}" publisher="SpringSource"/>
     <bean id="jtaPluginRuntimeDescriptor"

--- a/collection-plugins/jws/pom.xml
+++ b/collection-plugins/jws/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-jws</artifactId>

--- a/collection-plugins/jws/src/main/resources/META-INF/insight-plugin-jws.xml
+++ b/collection-plugins/jws/src/main/resources/META-INF/insight-plugin-jws.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="jws" version="${project.version}" publisher="SpringSource"/>
     <insight:operation-view operation="jws" template="com/springsource/insight/plugin/jws/jws.ftl"/>

--- a/collection-plugins/ldap/pom.xml
+++ b/collection-plugins/ldap/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-ldap</artifactId>

--- a/collection-plugins/ldap/src/main/resources/META-INF/insight-plugin-ldap.xml
+++ b/collection-plugins/ldap/src/main/resources/META-INF/insight-plugin-ldap.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="javax-naming-ldap" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/logging/pom.xml
+++ b/collection-plugins/logging/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-logging</artifactId>

--- a/collection-plugins/logging/src/main/resources/META-INF/insight-plugin-logging.xml
+++ b/collection-plugins/logging/src/main/resources/META-INF/insight-plugin-logging.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="logging" version="${project.version}" publisher="SpringSource"/>
     <insight:operation-view operation="logging" template="com/springsource/insight/plugin/logging/logging.ftl"/>

--- a/collection-plugins/mail/pom.xml
+++ b/collection-plugins/mail/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-javax-mail</artifactId>

--- a/collection-plugins/mail/src/main/resources/META-INF/insight-plugin-javax-mail.xml
+++ b/collection-plugins/mail/src/main/resources/META-INF/insight-plugin-javax-mail.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="javax-mail" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/mongodb/pom.xml
+++ b/collection-plugins/mongodb/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-mongodb</artifactId>

--- a/collection-plugins/mongodb/src/main/resources/META-INF/insight-plugin-mongodb.xml
+++ b/collection-plugins/mongodb/src/main/resources/META-INF/insight-plugin-mongodb.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-                http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+                http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="mongodb" version="${project.version}"
                     publisher="Stephen Harrison (stephen@harrison.org) and the Insight Team"/>

--- a/collection-plugins/mongodb/src/test/resources/META-INF/test-app-context.xml
+++ b/collection-plugins/mongodb/src/test/resources/META-INF/test-app-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
     <!--
         This Spring application context is only used in testing scenarios to setup the FreeMarker configuration. When
         the plugin is deployed within Spring Insight, this will already be provided.

--- a/collection-plugins/pom.xml
+++ b/collection-plugins/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight</groupId>
     <artifactId>community-plugins</artifactId>

--- a/collection-plugins/portlet/pom.xml
+++ b/collection-plugins/portlet/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-portlet</artifactId>

--- a/collection-plugins/portlet/src/main/resources/META-INF/insight-plugin-portlet.xml
+++ b/collection-plugins/portlet/src/main/resources/META-INF/insight-plugin-portlet.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="portlet" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/portlet/src/test/webapp/WEB-INF/portlet.xml
+++ b/collection-plugins/portlet/src/test/webapp/WEB-INF/portlet.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<portlet-app xmlns="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd"
+<portlet-app xmlns="https://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd"
              version="2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-Instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd
-                        http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd">
+             xsi:schemaLocation="https://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd
+                        https://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd">
 
     <portlet>
         <portlet-name>example-portlet</portlet-name>

--- a/collection-plugins/portlet/src/test/webapp/WEB-INF/web.xml
+++ b/collection-plugins/portlet/src/test/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-        "http://java.sun.com/dtd/web-app_2_3.dtd">
+        "https://java.sun.com/dtd/web-app_2_3.dtd">
 <web-app>
     <display-name>ExamplePortletApplication</display-name>
 </web-app>

--- a/collection-plugins/quartz/pom.xml
+++ b/collection-plugins/quartz/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-quartz-scheduler</artifactId>

--- a/collection-plugins/quartz/src/main/resources/META-INF/insight-plugin-quartz-scheduler.xml
+++ b/collection-plugins/quartz/src/main/resources/META-INF/insight-plugin-quartz-scheduler.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="quartz-scheduler" version="${project.version}" publisher="SpringSource"/>
     <insight:operation-view operation="quartz-scheduler"

--- a/collection-plugins/rabbitmq-client/pom.xml
+++ b/collection-plugins/rabbitmq-client/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-rabbitmq-client</artifactId>

--- a/collection-plugins/rabbitmq-client/src/main/resources/META-INF/insight-plugin-rabbitmq-client.xml
+++ b/collection-plugins/rabbitmq-client/src/main/resources/META-INF/insight-plugin-rabbitmq-client.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="rabbitmq-client" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/redis/pom.xml
+++ b/collection-plugins/redis/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-redis</artifactId>

--- a/collection-plugins/redis/src/main/resources/META-INF/insight-plugin-redis.xml
+++ b/collection-plugins/redis/src/main/resources/META-INF/insight-plugin-redis.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="redis" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/rmi/pom.xml
+++ b/collection-plugins/rmi/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-rmi</artifactId>

--- a/collection-plugins/rmi/src/main/resources/META-INF/insight-plugin-rmi.xml
+++ b/collection-plugins/rmi/src/main/resources/META-INF/insight-plugin-rmi.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="rmi" version="${project.version}" publisher="SpringSource"/>
     <insight:operation-view operation="rmi-action" template="com/springsource/insight/plugin/rmi/rmi-action.ftl"/>

--- a/collection-plugins/run-exec/pom.xml
+++ b/collection-plugins/run-exec/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-run-exec</artifactId>

--- a/collection-plugins/run-exec/src/main/resources/META-INF/insight-plugin-run-exec.xml
+++ b/collection-plugins/run-exec/src/main/resources/META-INF/insight-plugin-run-exec.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="run-exec" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/servlet/pom.xml
+++ b/collection-plugins/servlet/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-servlet</artifactId>

--- a/collection-plugins/servlet/src/main/resources/META-INF/insight-plugin-servlet.xml
+++ b/collection-plugins/servlet/src/main/resources/META-INF/insight-plugin-servlet.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="servlet" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/socket/pom.xml
+++ b/collection-plugins/socket/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-socket</artifactId>

--- a/collection-plugins/socket/src/main/resources/META-INF/insight-plugin-socket.xml
+++ b/collection-plugins/socket/src/main/resources/META-INF/insight-plugin-socket.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="socket" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/spring-batch/pom.xml
+++ b/collection-plugins/spring-batch/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-spring-batch</artifactId>

--- a/collection-plugins/spring-batch/src/main/resources/META-INF/insight-plugin-spring-batch.xml
+++ b/collection-plugins/spring-batch/src/main/resources/META-INF/insight-plugin-spring-batch.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="spring-batch" version="${project.version}" publisher="SpringSource"/>
     <insight:operation-view operation="spring-batch"

--- a/collection-plugins/spring-batch/src/test/resources/META-INF/jobContext.xml
+++ b/collection-plugins/spring-batch/src/test/resources/META-INF/jobContext.xml
@@ -4,9 +4,9 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="
                 http://www.springframework.org/schema/beans 
-                http://www.springframework.org/schema/beans/spring-beans.xsd
+                https://www.springframework.org/schema/beans/spring-beans.xsd
                 http://www.springframework.org/schema/batch 
-                http://www.springframework.org/schema/batch/spring-batch-2.0.xsd">
+                https://www.springframework.org/schema/batch/spring-batch-2.0.xsd">
 
     <beans:bean id="transactionManager"
                 class="org.springframework.batch.support.transaction.ResourcelessTransactionManager"/>

--- a/collection-plugins/spring-cloud/pom.xml
+++ b/collection-plugins/spring-cloud/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-spring-cloud</artifactId>

--- a/collection-plugins/spring-core/pom.xml
+++ b/collection-plugins/spring-core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-spring-core</artifactId>

--- a/collection-plugins/spring-core/src/main/resources/META-INF/insight-plugin-spring-core.xml
+++ b/collection-plugins/spring-core/src/main/resources/META-INF/insight-plugin-spring-core.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="spring-core" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/spring-core/src/test/resources/com/springsource/insight/plugin/springcore/test-class-path-scan-operation.xml
+++ b/collection-plugins/spring-core/src/test/resources/com/springsource/insight/plugin/springcore/test-class-path-scan-operation.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:component-scan base-package="com.springsource.insight.plugin.springcore"/>
 </beans>

--- a/collection-plugins/spring-data/pom.xml
+++ b/collection-plugins/spring-data/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-spring-data</artifactId>

--- a/collection-plugins/spring-data/src/main/resources/META-INF/insight-plugin-spring-data.xml
+++ b/collection-plugins/spring-data/src/main/resources/META-INF/insight-plugin-spring-data.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="spring-data" version="${project.version}" publisher="SpringSource"/>
     <insight:operation-view operation="spring-data-repository"

--- a/collection-plugins/spring-data/src/test/resources/META-INF/jpaTestContext.xml
+++ b/collection-plugins/spring-data/src/test/resources/META-INF/jpaTestContext.xml
@@ -8,17 +8,17 @@
        xmlns:tx="http://www.springframework.org/schema/tx"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans 
-           http://www.springframework.org/schema/beans/spring-beans.xsd
+           https://www.springframework.org/schema/beans/spring-beans.xsd
            http://www.springframework.org/schema/context
-           http://www.springframework.org/schema/context/spring-context.xsd
+           https://www.springframework.org/schema/context/spring-context.xsd
            http://www.springframework.org/schema/data/jpa
-           http://www.springframework.org/schema/data/jpa/spring-jpa-1.0.xsd
+           https://www.springframework.org/schema/data/jpa/spring-jpa-1.0.xsd
            http://www.springframework.org/schema/tx 
-           http://www.springframework.org/schema/tx/spring-tx.xsd
+           https://www.springframework.org/schema/tx/spring-tx.xsd
            http://www.springframework.org/schema/jdbc
-           http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+           https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
            http://www.springframework.org/schema/util
-           http://www.springframework.org/schema/util/spring-util.xsd">
+           https://www.springframework.org/schema/util/spring-util.xsd">
 
     <!-- Enabled annotation-based beans definitions -->
     <context:annotation-config/>

--- a/collection-plugins/spring-data/src/test/resources/META-INF/persistence.xml
+++ b/collection-plugins/spring-data/src/test/resources/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
              version="1.0">
     <persistence-unit name="springdatatest" transaction-type="RESOURCE_LOCAL">
         <class>com.springsource.insight.plugin.springdata.model.TestEntity</class>

--- a/collection-plugins/spring-integration/pom.xml
+++ b/collection-plugins/spring-integration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-spring-integration</artifactId>

--- a/collection-plugins/spring-integration/src/main/resources/META-INF/insight-plugin-spring-integration.xml
+++ b/collection-plugins/spring-integration/src/main/resources/META-INF/insight-plugin-spring-integration.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="spring-integration" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/spring-integration/src/test/resources/META-INF/test-app-context.xml
+++ b/collection-plugins/spring-integration/src/test/resources/META-INF/test-app-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
     <!--
         This Spring application context is only used in testing scenarios to setup the FreeMarker configuration. When

--- a/collection-plugins/spring-integration2/pom.xml
+++ b/collection-plugins/spring-integration2/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-spring-integration2</artifactId>

--- a/collection-plugins/spring-integration2/src/main/resources/META-INF/insight-plugin-spring-integration.xml
+++ b/collection-plugins/spring-integration2/src/main/resources/META-INF/insight-plugin-spring-integration.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="spring-integration2" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/spring-integration2/src/test/resources/META-INF/test-app-context.xml
+++ b/collection-plugins/spring-integration2/src/test/resources/META-INF/test-app-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
     <!--
         This Spring application context is only used in testing scenarios to setup the FreeMarker configuration. When

--- a/collection-plugins/spring-neo4j/pom.xml
+++ b/collection-plugins/spring-neo4j/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-spring-neo4j</artifactId>
@@ -21,7 +21,7 @@
     <repositories>
         <repository>
             <id>neo4j-releases</id>
-            <url>http://m2.neo4j.org/content/repositories/releases</url>
+            <url>https://m2.neo4j.org/content/repositories/releases</url>
         </repository>
     </repositories>
 

--- a/collection-plugins/spring-neo4j/src/main/resources/META-INF/insight-plugin-spring-neo4j.xml
+++ b/collection-plugins/spring-neo4j/src/main/resources/META-INF/insight-plugin-spring-neo4j.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="spring-neo4j" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/spring-neo4j/src/test/resources/META-INF/spring-neo4j-plugin-test-context.xml
+++ b/collection-plugins/spring-neo4j/src/test/resources/META-INF/spring-neo4j-plugin-test-context.xml
@@ -3,9 +3,9 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:neo4j="http://www.springframework.org/schema/data/neo4j"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/data/neo4j http://www.springframework.org/schema/data/neo4j/spring-neo4j-2.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/data/neo4j https://www.springframework.org/schema/data/neo4j/spring-neo4j-2.0.xsd">
 
     <context:annotation-config/>
 

--- a/collection-plugins/spring-security/pom.xml
+++ b/collection-plugins/spring-security/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-spring-security</artifactId>

--- a/collection-plugins/spring-security/src/main/resources/META-INF/insight-plugin-spring-security.xml
+++ b/collection-plugins/spring-security/src/main/resources/META-INF/insight-plugin-spring-security.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="spring-security" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/spring-tx/pom.xml
+++ b/collection-plugins/spring-tx/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-spring-tx</artifactId>

--- a/collection-plugins/spring-tx/src/main/resources/META-INF/insight-plugin-springtx.xml
+++ b/collection-plugins/spring-tx/src/main/resources/META-INF/insight-plugin-springtx.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="spring-tx" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/spring-web/pom.xml
+++ b/collection-plugins/spring-web/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-spring-web</artifactId>

--- a/collection-plugins/spring-web/src/main/resources/META-INF/insight-plugin-springweb.xml
+++ b/collection-plugins/spring-web/src/main/resources/META-INF/insight-plugin-springweb.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="spring-web" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/spring-webflow/pom.xml
+++ b/collection-plugins/spring-webflow/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-spring-webflow</artifactId>

--- a/collection-plugins/spring-webflow/src/main/resources/META-INF/insight-plugin-spring-webflow.xml
+++ b/collection-plugins/spring-webflow/src/main/resources/META-INF/insight-plugin-spring-webflow.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="webflow" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/spring-webflow/src/test/resources/webflow-test.xml
+++ b/collection-plugins/spring-webflow/src/test/resources/webflow-test.xml
@@ -2,7 +2,7 @@
 <flow xmlns="http://www.springframework.org/schema/webflow"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://www.springframework.org/schema/webflow
-                          http://www.springframework.org/schema/webflow/spring-webflow-2.0.xsd">
+                          https://www.springframework.org/schema/webflow/spring-webflow-2.0.xsd">
 
     <input name="id"/>
 

--- a/collection-plugins/struts2/pom.xml
+++ b/collection-plugins/struts2/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-struts2</artifactId>

--- a/collection-plugins/struts2/src/main/resources/META-INF/insight-plugin-struts2.xml
+++ b/collection-plugins/struts2/src/main/resources/META-INF/insight-plugin-struts2.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="struts2" version="${project.version}" publisher="SpringSource"/>
 

--- a/collection-plugins/struts2/src/test/resources/struts.xml
+++ b/collection-plugins/struts2/src/test/resources/struts.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE struts PUBLIC
         "-//Apache Software Foundation//DTD Struts Configuration 2.0//EN"
-        "http://struts.apache.org/dtds/struts-2.0.dtd">
+        "https://struts.apache.org/dtds/struts-2.0.dtd">
 
 <struts>
 

--- a/collection-plugins/tomcat/pom.xml
+++ b/collection-plugins/tomcat/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.plugins</groupId>
     <artifactId>insight-plugin-tomcat</artifactId>

--- a/collection-plugins/tomcat/src/main/resources/META-INF/insight-plugin-tomcat.xml
+++ b/collection-plugins/tomcat/src/main/resources/META-INF/insight-plugin-tomcat.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="tomcat" version="${project.version}" publisher="SpringSource"/>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight</groupId>
     <artifactId>community-core</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight</groupId>
     <artifactId>community</artifactId>
@@ -262,14 +262,14 @@
 
     <organization>
         <name>VMware, Inc.</name>
-        <url>http://springsource.org/insight</url>
+        <url>https://springsource.org/insight</url>
     </organization>
 
     <repositories>
         <repository>
             <id>maven.springframework.org</id>
             <name>SpringSource snapshots</name>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -277,7 +277,7 @@
         <repository>    <!-- NOTE: these values must match the properties -->
             <id>spring-release</id>
             <name>Spring Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -288,7 +288,7 @@
         <repository>    <!-- NOTE: these values must match the properties -->
             <id>spring-milestone</id>
             <name>Spring Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -321,7 +321,7 @@
         <repository>
             <id>org.jboss.maven.release.nexus</id>
             <name>JBoss Maven Central-compatible Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -332,7 +332,7 @@
         <repository>
             <id>org.jboss.maven.release</id>
             <name>JBoss Maven Central-compatible Repository</name>
-            <url>http://repository.jboss.com/maven2</url>
+            <url>http://repository.jboss.com/maven2/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -359,7 +359,7 @@
         <pluginRepository>    <!-- NOTE: these values must match the properties -->
             <id>spring-release</id>
             <name>Spring Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -371,7 +371,7 @@
         <pluginRepository>    <!-- NOTE: these values must match the properties -->
             <id>spring-milestone</id>
             <name>Spring Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -382,7 +382,7 @@
         <pluginRepository>
             <id>org.jboss.maven.release.nexus</id>
             <name>JBoss Maven Central-compatible Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -393,7 +393,7 @@
         <pluginRepository>
             <id>maven.springframework.org</id>
             <name>SpringSource snapshots</name>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -1061,7 +1061,7 @@
                         </execution>
                         <execution>
                             <id>compile-test-aspects</id>
-                            <!-- see http://jira.codehaus.org/browse/MASPECTJ-92 workaround -->
+                            <!-- see https://jira.codehaus.org/browse/MASPECTJ-92 workaround -->
                             <phase>process-test-sources</phase>
                             <goals>
                                 <goal>test-compile</goal>
@@ -1171,7 +1171,7 @@
                         <quiet>true</quiet>
                         <links>
                             <link>http://docs.mockito.googlecode.com/hg/${mockito.version}</link>
-                            <link>http://kentbeck.github.com/junit/javadoc/${junit.version}</link>
+                            <link>https://kentbeck.github.com/junit/javadoc/${junit.version}</link>
                         </links>
                     </configuration>
                 </plugin>
@@ -1266,7 +1266,7 @@
                             <goal>execute</goal>
                         </goals>
                         <configuration>
-                            <!-- see http://maven.apache.org/ref/3.0.4/maven-core/apidocs/org/apache/maven/execution/MavenSession.html -->
+                            <!-- see https://maven.apache.org/ref/3.0.4/maven-core/apidocs/org/apache/maven/execution/MavenSession.html -->
                             <source>
                                 <![CDATA[
 								if (!session.goals.contains("deploy")) {

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight</groupId>
     <artifactId>community-build</artifactId>

--- a/samples/payme-insight-plugin/pom.xml
+++ b/samples/payme-insight-plugin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.samples</groupId>
     <artifactId>payme-insight-plugin</artifactId>

--- a/samples/payme-insight-plugin/src/main/resources/META-INF/insight-plugin-myplugin.xml
+++ b/samples/payme-insight-plugin/src/main/resources/META-INF/insight-plugin-myplugin.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:insight="http://www.springframework.org/schema/insight-idk"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/insight-idk http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/insight-idk https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd">
 
     <insight:plugin name="payme" version="1.0" publisher="[your name here]"/>
 

--- a/samples/payme-insight-plugin/src/test/resources/META-INF/test-app-context.xml
+++ b/samples/payme-insight-plugin/src/test/resources/META-INF/test-app-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
     <!--
         This Spring application context is only used in testing scenarios to setup the FreeMarker configuration. When

--- a/samples/payme-webapp/pom.xml
+++ b/samples/payme-webapp/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.samples</groupId>
     <artifactId>payme-webapp</artifactId>

--- a/samples/payme-webapp/src/main/webapp/WEB-INF/payme-servlet.xml
+++ b/samples/payme-webapp/src/main/webapp/WEB-INF/payme-servlet.xml
@@ -3,9 +3,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
        xmlns:context="http://www.springframework.org/schema/context"
        xmlns:oxm="http://www.springframework.org/schema/oxm"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-				http://www.springframework.org/schema/oxm http://www.springframework.org/schema/oxm/spring-oxm.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+				http://www.springframework.org/schema/oxm https://www.springframework.org/schema/oxm/spring-oxm.xsd">
 
     <context:component-scan base-package="com.springsource.insight.samples.payme"/>
 

--- a/samples/payme-webapp/src/main/webapp/WEB-INF/spring/applicationContext.xml
+++ b/samples/payme-webapp/src/main/webapp/WEB-INF/spring/applicationContext.xml
@@ -4,10 +4,10 @@
        xmlns:p="http://www.springframework.org/schema/p" xmlns:context="http://www.springframework.org/schema/context"
        xmlns:tx="http://www.springframework.org/schema/tx"
        xsi:schemaLocation="
-			http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-			http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-			http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-			http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+			http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+			http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
 
     <context:annotation-config/>
 </beans>

--- a/samples/payme-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/samples/payme-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <web-app version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
 
     <display-name>PayMe</display-name>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.springsource.insight.samples</groupId>
     <artifactId>sample-modules</artifactId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://repository.jboss.com/maven2 (301) with 1 occurrences could not be migrated:  
   ([https](https://repository.jboss.com/maven2) result SSLHandshakeException).
* http://maven.hyperic.org/external (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.hyperic.org/external) result SSLHandshakeException).
* http://private.maven.springsource.com/milestone (403) with 1 occurrences could not be migrated:  
   ([https](https://private.maven.springsource.com/milestone) result SSLHandshakeException).
* http://private.maven.springsource.com/release (403) with 1 occurrences could not be migrated:  
   ([https](https://private.maven.springsource.com/release) result SSLHandshakeException).
* http://private.maven.springsource.com/snapshot (403) with 2 occurrences could not be migrated:  
   ([https](https://private.maven.springsource.com/snapshot) result SSLHandshakeException).
* http://dist.gemstone.com/maven/release (404) with 1 occurrences could not be migrated:  
   ([https](https://dist.gemstone.com/maven/release) result SSLHandshakeException).
* http://docs.mockito.googlecode.com/hg/ (404) with 1 occurrences could not be migrated:  
   ([https](https://docs.mockito.googlecode.com/hg/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.axonframework.org (301) with 1 occurrences migrated to:  
  https://axoniq.io ([https](https://www.axonframework.org) result SSLHandshakeException).
* http://www.gemstone.com/dtd/cache6_5.dtd (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://www.gemstone.com/dtd/cache6_5.dtd ([https](https://www.gemstone.com/dtd/cache6_5.dtd) result ConnectTimeoutException).
* http://internal/ehcache/app/tc-config.xml (UnknownHostException) with 1 occurrences migrated to:  
  https://internal/ehcache/app/tc-config.xml ([https](https://internal/ehcache/app/tc-config.xml) result UnknownHostException).
* http://jira.codehaus.org/browse/MASPECTJ-92 (UnknownHostException) with 1 occurrences migrated to:  
  https://jira.codehaus.org/browse/MASPECTJ-92 ([https](https://jira.codehaus.org/browse/MASPECTJ-92) result UnknownHostException).
* http://www.springframework.org/schema/data/neo4j/spring-neo4j-2.0.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/data/neo4j/spring-neo4j-2.0.xsd ([https](https://www.springframework.org/schema/data/neo4j/spring-neo4j-2.0.xsd) result 404).
* http://www.springframework.org/schema/webflow/spring-webflow-2.0.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/webflow/spring-webflow-2.0.xsd ([https](https://www.springframework.org/schema/webflow/spring-webflow-2.0.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://jackrabbit.apache.org/dtd/repository-2.0.dtd with 1 occurrences migrated to:  
  https://jackrabbit.apache.org/dtd/repository-2.0.dtd ([https](https://jackrabbit.apache.org/dtd/repository-2.0.dtd) result 200).
* http://maven.apache.org/ref/3.0.4/maven-core/apidocs/org/apache/maven/execution/MavenSession.html with 1 occurrences migrated to:  
  https://maven.apache.org/ref/3.0.4/maven-core/apidocs/org/apache/maven/execution/MavenSession.html ([https](https://maven.apache.org/ref/3.0.4/maven-core/apidocs/org/apache/maven/execution/MavenSession.html) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 6 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://struts.apache.org/dtds/struts-2.0.dtd with 1 occurrences migrated to:  
  https://struts.apache.org/dtds/struts-2.0.dtd ([https](https://struts.apache.org/dtds/struts-2.0.dtd) result 200).
* http://www.springframework.org/schema/aop/spring-aop.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop.xsd ([https](https://www.springframework.org/schema/aop/spring-aop.xsd) result 200).
* http://www.springframework.org/schema/batch/spring-batch-2.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/batch/spring-batch-2.0.xsd ([https](https://www.springframework.org/schema/batch/spring-batch-2.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-2.0.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-2.5.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.5.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.5.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 56 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 7 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/data/jpa/spring-jpa-1.0.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/data/jpa/spring-jpa-1.0.xsd ([https](https://www.springframework.org/schema/data/jpa/spring-jpa-1.0.xsd) result 200).
* http://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd with 49 occurrences migrated to:  
  https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd ([https](https://www.springframework.org/schema/insight-idk/insight-idk-1.0.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc.xsd) result 200).
* http://www.springframework.org/schema/oxm/spring-oxm.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/oxm/spring-oxm.xsd ([https](https://www.springframework.org/schema/oxm/spring-oxm.xsd) result 200).
* http://www.springframework.org/schema/tx/spring-tx.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx.xsd ([https](https://www.springframework.org/schema/tx/spring-tx.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* http://download.eclipse.org/rt/eclipselink/maven.repo with 1 occurrences migrated to:  
  https://download.eclipse.org/rt/eclipselink/maven.repo ([https](https://download.eclipse.org/rt/eclipselink/maven.repo) result 301).
* http://kentbeck.github.com/junit/javadoc/ with 1 occurrences migrated to:  
  https://kentbeck.github.com/junit/javadoc/ ([https](https://kentbeck.github.com/junit/javadoc/) result 301).
* http://m2.neo4j.org/content/repositories/releases with 1 occurrences migrated to:  
  https://m2.neo4j.org/content/repositories/releases ([https](https://m2.neo4j.org/content/repositories/releases) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 50 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://repository.jboss.org/nexus/content/groups/public with 2 occurrences migrated to:  
  https://repository.jboss.org/nexus/content/groups/public ([https](https://repository.jboss.org/nexus/content/groups/public) result 301).
* http://java.sun.com/dtd/web-app_2_3.dtd with 1 occurrences migrated to:  
  https://java.sun.com/dtd/web-app_2_3.dtd ([https](https://java.sun.com/dtd/web-app_2_3.dtd) result 302).
* http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd with 1 occurrences migrated to:  
  https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd ([https](https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd) result 302).
* http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd with 2 occurrences migrated to:  
  https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd ([https](https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd) result 302).
* http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd with 3 occurrences migrated to:  
  https://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd ([https](https://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd) result 302).
* http://maven.springframework.org/milestone with 2 occurrences migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release with 2 occurrences migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://maven.springframework.org/snapshot with 2 occurrences migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* http://repo.typesafe.com/typesafe/releases/ with 1 occurrences migrated to:  
  https://repo.typesafe.com/typesafe/releases/ ([https](https://repo.typesafe.com/typesafe/releases/) result 302).
* http://springsource.org/insight with 1 occurrences migrated to:  
  https://springsource.org/insight ([https](https://springsource.org/insight) result 302).
* http://www.terracotta.org/web/display/orgsite/Download with 1 occurrences migrated to:  
  https://www.terracotta.org/web/display/orgsite/Download ([https](https://www.terracotta.org/web/display/orgsite/Download) result 302).

# Ignored
These URLs were intentionally ignored.

* http://jakarta.apache.org/log4j/ with 2 occurrences
* http://java.sun.com/xml/ns/j2ee with 2 occurrences
* http://java.sun.com/xml/ns/persistence with 4 occurrences
* http://localhost:7474/db/data with 1 occurrences
* http://localhost:8081/artifactory/libs-releases-local with 1 occurrences
* http://localhost:8081/artifactory/libs-snapshots-local with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 112 occurrences
* http://www.springframework.org/schema/aop with 2 occurrences
* http://www.springframework.org/schema/batch with 2 occurrences
* http://www.springframework.org/schema/beans with 126 occurrences
* http://www.springframework.org/schema/context with 14 occurrences
* http://www.springframework.org/schema/data/jpa with 4 occurrences
* http://www.springframework.org/schema/data/neo4j with 2 occurrences
* http://www.springframework.org/schema/insight-idk with 98 occurrences
* http://www.springframework.org/schema/jdbc with 6 occurrences
* http://www.springframework.org/schema/oxm with 2 occurrences
* http://www.springframework.org/schema/p with 6 occurrences
* http://www.springframework.org/schema/tx with 6 occurrences
* http://www.springframework.org/schema/util with 4 occurrences
* http://www.springframework.org/schema/webflow with 2 occurrences
* http://www.w3.org/2001/XMLSchema-Instance with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 124 occurrences