### PR TITLE
URL Cleanup

### DIFF
--- a/aslHeader.txt
+++ b/aslHeader.txt
@@ -4,7 +4,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/ActorRefOperationCollectionAspect.aj
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/ActorRefOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/AkkaDefinitions.java
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/AkkaDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/AkkaPluginRuntimeDescriptor.java
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/AkkaPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/AkkaUntypedActorEndPointAnalyzer.java
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/AkkaUntypedActorEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/UntypedActorOperationCollectionAspect.aj
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/UntypedActorOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/actorref/ActorRefHelper.java
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/actorref/ActorRefHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/actorref/ActorRefPropertyExtractor.java
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/actorref/ActorRefPropertyExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/actorref/PromiseActorRefPropertyExtractor.java
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/actorref/PromiseActorRefPropertyExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/actorref/RouterActorRefPropertyExtractor.java
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/actorref/RouterActorRefPropertyExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/routing/AkkaRouterConfigHelper.java
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/routing/AkkaRouterConfigHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/routing/RoundRobinRouterDataExtractor.java
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/routing/RoundRobinRouterDataExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/routing/RouterConfigDataExtractor.java
+++ b/collection-plugins/akka/src/main/java/com/springsource/insight/plugin/akka/routing/RouterConfigDataExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/AbstractAkkaOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/AbstractAkkaOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/UntypedActorOperationCollectionAspectTest.java
+++ b/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/UntypedActorOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/actorref/PromiseActorRefPropertyExtractorTest.java
+++ b/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/actorref/PromiseActorRefPropertyExtractorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/actorref/RouterActorRefPropertyExtractorTest.java
+++ b/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/actorref/RouterActorRefPropertyExtractorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/routing/AkkaRouterConfigHelperTest.java
+++ b/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/routing/AkkaRouterConfigHelperTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/routing/RoundRobinRouterDataExtractorTest.java
+++ b/collection-plugins/akka/src/test/java/com/springsource/insight/plugin/akka/routing/RoundRobinRouterDataExtractorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/aslHeader.txt
+++ b/collection-plugins/axon/aslHeader.txt
@@ -4,7 +4,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/AbstractHandlerEndPointAnalyzer.java
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/AbstractHandlerEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/Axon20OperationUtils.java
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/Axon20OperationUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/AxonOperationType.java
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/AxonOperationType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/AxonPluginRuntimeDescriptor.java
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/AxonPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/AxonVersion.java
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/AxonVersion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/CommandBus1xDispatchOperationCollectionAspect.aj
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/CommandBus1xDispatchOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/CommandBus20DispatchOperationCollectionAspect.aj
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/CommandBus20DispatchOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/CommandHandlerEndPointAnalyzer.java
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/CommandHandlerEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/CommandHandlerOperationCollectionAspect.aj
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/CommandHandlerOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/EventBus1xPublishOperationCollectionAspect.aj
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/EventBus1xPublishOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/EventBus20PublishOperationCollectionAspect.aj
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/EventBus20PublishOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/EventHandlerEndPointAnalyzer.java
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/EventHandlerEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/EventHandlerOperationCollectionAspect.aj
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/EventHandlerOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/SagaOperationCollectionAspect.aj
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/SagaOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/SagaOperationEndPointAnalyzer.java
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/SagaOperationEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/test/java/org/axonframework/insight/plugin/axon/CommandHandlerOperationCollectionAspectTest.java
+++ b/collection-plugins/axon/src/test/java/org/axonframework/insight/plugin/axon/CommandHandlerOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/test/java/org/axonframework/insight/plugin/axon/EventHandlerOperationCollectionAspectTest.java
+++ b/collection-plugins/axon/src/test/java/org/axonframework/insight/plugin/axon/EventHandlerOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/test/java/org/axonframework/insight/plugin/axon/ExposedAxonPluginSpringBeanTest.java
+++ b/collection-plugins/axon/src/test/java/org/axonframework/insight/plugin/axon/ExposedAxonPluginSpringBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/axon/src/test/resources/log4j.properties
+++ b/collection-plugins/axon/src/test/resources/log4j.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/AbsCassandraExternalResourceAnalyzer.java
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/AbsCassandraExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/AbstractCassandraOperationCollectionAspect.aj
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/AbstractCassandraOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CQLOperationCollectionAspect.aj
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CQLOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraCQLExternalResourceAnalyzer.java
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraCQLExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraConnectExternalResourceAnalyzer.java
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraConnectExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraGetExternalResourceAnalyzer.java
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraGetExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraPluginRuntimeDescriptor.java
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraRemoveExternalResourceAnalyzer.java
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraRemoveExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraSystemExternalResourceAnalyzer.java
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraSystemExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraUpdateExternalResourceAnalyzer.java
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/CassandraUpdateExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/ConnectOperationCollectionAspect.aj
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/ConnectOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/GetOperationCollectionAspect.aj
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/GetOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/OperationCollectionTypes.java
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/OperationCollectionTypes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/OperationUtils.aj
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/OperationUtils.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/RemoveOperationCollectionAspect.aj
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/RemoveOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/SystemOperationCollectionAspect.aj
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/SystemOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/UpdateOperationCollectionAspect.aj
+++ b/collection-plugins/cassandra/src/main/java/com/springsource/insight/plugin/cassandra/UpdateOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/AbstractOperationCollectionAspectTest.java
+++ b/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/AbstractOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/CassandraUnitTests.java
+++ b/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/CassandraUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/ConnectOperationCollectionAspectTest.java
+++ b/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/ConnectOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/GetOperationCollectionAspectTest.java
+++ b/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/GetOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/InsertOperationCollectionAspectTest.java
+++ b/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/InsertOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/SystemOperationCollectionAspectTest.java
+++ b/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/SystemOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/embeded/EmbeddedCassandraService.java
+++ b/collection-plugins/cassandra/src/test/java/com/springsource/insight/plugin/cassandra/embeded/EmbeddedCassandraService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/DatabaseSessionMetricsGenerator.java
+++ b/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/DatabaseSessionMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/DatabaseSessionOperationCollectionAspect.aj
+++ b/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/DatabaseSessionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistenceCollectionAspect.aj
+++ b/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistenceCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistenceDefinitions.java
+++ b/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistenceDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistenceMetricsGenerator.java
+++ b/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistenceMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistencePluginRuntimeDescriptor.java
+++ b/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistencePluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/SessionQueryMetricsGenerator.java
+++ b/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/SessionQueryMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/SessionQueryOperationCollectionAspect.aj
+++ b/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/SessionQueryOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/SessionQueryOperationJoinPointFinalizer.java
+++ b/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/SessionQueryOperationJoinPointFinalizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/TransactionOperationCollectionAspect.aj
+++ b/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/TransactionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/TransactionOperationMetricsGenerator.java
+++ b/collection-plugins/eclipse-persistence/src/main/java/com/springsource/insight/plugin/eclipse/persistence/TransactionOperationMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/DatabaseSessionMetricsGeneratorTest.java
+++ b/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/DatabaseSessionMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/DatabaseSessionOperationCollectionAspectTest.java
+++ b/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/DatabaseSessionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistenceCollectionTestSupport.java
+++ b/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistenceCollectionTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistenceMetricsGeneratorTestSupport.java
+++ b/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/EclipsePersistenceMetricsGeneratorTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/MockDatabaseSession.java
+++ b/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/MockDatabaseSession.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/SessionQueryMetricsGeneratorTest.java
+++ b/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/SessionQueryMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/SessionQueryOperationCollectionAspectTest.java
+++ b/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/SessionQueryOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/TransactionOperationCollectionAspectTest.java
+++ b/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/TransactionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/TransactionOperationMetricsGeneratorTest.java
+++ b/collection-plugins/eclipse-persistence/src/test/java/com/springsource/insight/plugin/eclipse/persistence/TransactionOperationMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheCollapsingFrameHelper.java
+++ b/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheCollapsingFrameHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheDefinitions.java
+++ b/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheExternalResourceAnalyzer.java
+++ b/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheGetOperationCollectionAspect.aj
+++ b/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheGetOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheMethodOperationCollectionAspect.aj
+++ b/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheMethodOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcachePutOperationCollectionAspect.aj
+++ b/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcachePutOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheRemoveOperationCollectionAspect.aj
+++ b/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheRemoveOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheReplaceOperationCollectionAspect.aj
+++ b/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcacheReplaceOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcahePluginRuntimeDescriptor.java
+++ b/collection-plugins/ehcache/src/main/java/com/springsource/insight/plugin/ehcache/EhcahePluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheBenchmarkTest.java
+++ b/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheBenchmarkTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheGetOperationCollectionAspectTest.java
+++ b/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheGetOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcachePutOperationCollectionAspectTest.java
+++ b/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcachePutOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheRemoveOperationCollectionAspectTest.java
+++ b/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheRemoveOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheReplaceOperationCollectionAspectTest.java
+++ b/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheReplaceOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheResourceAnalyzerTest.java
+++ b/collection-plugins/ehcache/src/test/java/com/springsource/insight/plugin/ehcache/EhcacheResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ejb3/src/main/java/com/springsource/insight/collection/method/TrailingMethodOperationCollectionAspect.aj
+++ b/collection-plugins/ejb3/src/main/java/com/springsource/insight/collection/method/TrailingMethodOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ejb3/src/main/java/com/springsource/insight/plugin/ejb3/Ejb3LocalServiceDefinitions.java
+++ b/collection-plugins/ejb3/src/main/java/com/springsource/insight/plugin/ejb3/Ejb3LocalServiceDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ejb3/src/main/java/com/springsource/insight/plugin/ejb3/Ejb3LocalServiceEndPointAnalyzer.java
+++ b/collection-plugins/ejb3/src/main/java/com/springsource/insight/plugin/ejb3/Ejb3LocalServiceEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ejb3/src/main/java/com/springsource/insight/plugin/ejb3/Ejb3LocalServiceOperationCollectionAspect.aj
+++ b/collection-plugins/ejb3/src/main/java/com/springsource/insight/plugin/ejb3/Ejb3LocalServiceOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ejb3/src/main/java/com/springsource/insight/plugin/ejb3/Ejb3PluginRuntimeDescriptor.java
+++ b/collection-plugins/ejb3/src/main/java/com/springsource/insight/plugin/ejb3/Ejb3PluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ejb3/src/test/java/com/springsource/insight/plugin/ejb3/Ejb3LocalServiceOperationCollectionAspectTest.java
+++ b/collection-plugins/ejb3/src/test/java/com/springsource/insight/plugin/ejb3/Ejb3LocalServiceOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ejb3/src/test/java/com/springsource/insight/plugin/ejb3/ExampleEjb3LocalService.java
+++ b/collection-plugins/ejb3/src/test/java/com/springsource/insight/plugin/ejb3/ExampleEjb3LocalService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ejb3/src/test/java/com/springsource/insight/plugin/ejb3/ExampleStatefulEjb3LocalServiceAction.java
+++ b/collection-plugins/ejb3/src/test/java/com/springsource/insight/plugin/ejb3/ExampleStatefulEjb3LocalServiceAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ejb3/src/test/java/com/springsource/insight/plugin/ejb3/ExampleStatelessEjb3LocalServiceAction.java
+++ b/collection-plugins/ejb3/src/test/java/com/springsource/insight/plugin/ejb3/ExampleStatelessEjb3LocalServiceAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/AbstractFilesTrackerAspectSupport.java
+++ b/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/AbstractFilesTrackerAspectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FileCloseCollectionAspect.aj
+++ b/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FileCloseCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FileInputCollectionAspect.aj
+++ b/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FileInputCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FileOpenTrackerAspectSupport.java
+++ b/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FileOpenTrackerAspectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FileOutputCollectionAspect.aj
+++ b/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FileOutputCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FilesTrackerDefinitions.java
+++ b/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FilesTrackerDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FilesTrackerExternalResourceAnalyzer.java
+++ b/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FilesTrackerExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FilesTrackerPluginRuntimeDescriptor.java
+++ b/collection-plugins/files-tracker/src/main/java/com/springsource/insight/plugin/files/tracker/FilesTrackerPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FileInputCollectionAspectTest.java
+++ b/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FileInputCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FileOutputCollectionAspectTest.java
+++ b/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FileOutputCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FilesCacheTest.java
+++ b/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FilesCacheTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FilesOpenTrackerAspectTestSupport.java
+++ b/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FilesOpenTrackerAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FilesTrackerAspectTestSupport.java
+++ b/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FilesTrackerAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FilesTrackerExternalResourceAnalyzerTest.java
+++ b/collection-plugins/files-tracker/src/test/java/com/springsource/insight/plugin/files/tracker/FilesTrackerExternalResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/AbstractGemFireCollectionAspect.aj
+++ b/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/AbstractGemFireCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/AbstractGemFireExternalResourceAnalyzer.java
+++ b/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/AbstractGemFireExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireDefenitions.java
+++ b/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireDefenitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireLightPluginRuntimeDescriptor.java
+++ b/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireLightPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireLightPointcuts.aj
+++ b/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireLightPointcuts.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireQueryCollectionAspect.aj
+++ b/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireQueryCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireQueryExternalResourceAnalyzer.java
+++ b/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireQueryExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRemoteExternalResourceAnalyzer.java
+++ b/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRemoteExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRemoteOperationCollectionAspect.aj
+++ b/collection-plugins/gemfire-light/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRemoteOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/AbstractGemFireExternalResourceAnalyzerTestSupport.java
+++ b/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/AbstractGemFireExternalResourceAnalyzerTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/GemFireAspectTestSupport.java
+++ b/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/GemFireAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/GemFireQueryCollectionAspectTest.java
+++ b/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/GemFireQueryCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/GemFireQueryExternalResourceAnalyzerTest.java
+++ b/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/GemFireQueryExternalResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRemoteCollectionAspectTest.java
+++ b/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRemoteCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRemoteExternalResourceAnalyzerTest.java
+++ b/collection-plugins/gemfire-light/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRemoteExternalResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/AbstractGemFireCollectionAspect.aj
+++ b/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/AbstractGemFireCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/AbstractGemFireExternalResourceAnalyzer.java
+++ b/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/AbstractGemFireExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireDefenitions.java
+++ b/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireDefenitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFirePluginRuntimeDescriptor.java
+++ b/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFirePluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireQueryCollectionAspect.aj
+++ b/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireQueryCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireQueryExternalResourceAnalyzer.java
+++ b/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireQueryExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRegionCollectionAspect.aj
+++ b/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRegionCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRegionExternalResourceAnalyzer.java
+++ b/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRegionExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRemoteExternalResourceAnalyzer.java
+++ b/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRemoteExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRemoteOperationCollectionAspect.aj
+++ b/collection-plugins/gemfire/src/main/java/com/springsource/insight/plugin/gemfire/GemFireRemoteOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/AbstractGemFireExternalResourceAnalyzerTestSupport.java
+++ b/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/AbstractGemFireExternalResourceAnalyzerTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireAspectTestSupport.java
+++ b/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireQueryCollectionAspectTest.java
+++ b/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireQueryCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireQueryExternalResourceAnalyzerTest.java
+++ b/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireQueryExternalResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRegionCollectionAspectTest.java
+++ b/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRegionCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRegionExternalResourceAnalyzerTest.java
+++ b/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRegionExternalResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRemoteCollectionAspectTest.java
+++ b/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRemoteCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRemoteExternalResourceAnalyzerTest.java
+++ b/collection-plugins/gemfire/src/test/java/com/springsource/insight/plugin/gemfire/GemFireRemoteExternalResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerClassAspect.aj
+++ b/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerClassAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerInstanceAspect.aj
+++ b/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerInstanceAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerMethodEndPointAnalyzer.java
+++ b/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerMethodEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerMetricCollector.java
+++ b/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerMetricCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerOperationCollectionAspect.aj
+++ b/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerPointcuts.aj
+++ b/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerPointcuts.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerStateKeeper.java
+++ b/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsControllerStateKeeper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsPluginRuntimeDescriptor.java
+++ b/collection-plugins/grails/src/main/java/com/springsource/insight/plugin/grails/GrailsPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/ExposedGrailsPluginSpringBeanTest.java
+++ b/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/ExposedGrailsPluginSpringBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/GrailsControllerMethodEndPointAnalyzerTest.java
+++ b/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/GrailsControllerMethodEndPointAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/GrailsControllerMethodViewTest.java
+++ b/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/GrailsControllerMethodViewTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/GrailsControllerMetricCollectorTest.java
+++ b/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/GrailsControllerMetricCollectorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/GrailsControllerOperationCollectionAspectTest.java
+++ b/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/GrailsControllerOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/GrailsControllerStateKeeperTest.java
+++ b/collection-plugins/grails/src/test/java/com/springsource/insight/plugin/grails/GrailsControllerStateKeeperTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/HadoopExternalResourceAnalyzer.java
+++ b/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/HadoopExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/HadoopPluginRuntimeDescriptor.java
+++ b/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/HadoopPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/JobClientOperationCollectionAspect.aj
+++ b/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/JobClientOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/JobOperationCollectionAspect.aj
+++ b/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/JobOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/MapOperationCollectionAspect.aj
+++ b/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/MapOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/OperationCollectionTypes.java
+++ b/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/OperationCollectionTypes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/ReduceOperationCollectionAspect.aj
+++ b/collection-plugins/hadoop/src/main/java/com/springsource/insight/plugin/hadoop/ReduceOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hadoop/src/test/java/com/springsource/insight/plugin/hadoop/JobOperationCollectionAspectTest.java
+++ b/collection-plugins/hadoop/src/test/java/com/springsource/insight/plugin/hadoop/JobOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hadoop/src/test/java/com/springsource/insight/plugin/hadoop/WordCount.java
+++ b/collection-plugins/hadoop/src/test/java/com/springsource/insight/plugin/hadoop/WordCount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hibernate/src/main/java/com/springsource/insight/plugin/hibernate/HibernateEventCollectionAspect.aj
+++ b/collection-plugins/hibernate/src/main/java/com/springsource/insight/plugin/hibernate/HibernateEventCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hibernate/src/main/java/com/springsource/insight/plugin/hibernate/HibernatePluginRuntimeDescriptor.java
+++ b/collection-plugins/hibernate/src/main/java/com/springsource/insight/plugin/hibernate/HibernatePluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hibernate/src/main/java/com/springsource/insight/plugin/hibernate/HibernateSessionOperationCollectionAspect.aj
+++ b/collection-plugins/hibernate/src/main/java/com/springsource/insight/plugin/hibernate/HibernateSessionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hibernate/src/test/java/com/springsource/insight/plugin/hibernate/DummyDirtyCheckListenerImpl.java
+++ b/collection-plugins/hibernate/src/test/java/com/springsource/insight/plugin/hibernate/DummyDirtyCheckListenerImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hibernate/src/test/java/com/springsource/insight/plugin/hibernate/DummyFlushEventListenerImpl.java
+++ b/collection-plugins/hibernate/src/test/java/com/springsource/insight/plugin/hibernate/DummyFlushEventListenerImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hibernate/src/test/java/com/springsource/insight/plugin/hibernate/DummySessionImpl.java
+++ b/collection-plugins/hibernate/src/test/java/com/springsource/insight/plugin/hibernate/DummySessionImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hibernate/src/test/java/com/springsource/insight/plugin/hibernate/HibernateEventCollectionAspectTest.java
+++ b/collection-plugins/hibernate/src/test/java/com/springsource/insight/plugin/hibernate/HibernateEventCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/hibernate/src/test/java/com/springsource/insight/plugin/hibernate/HibernateSessionOperationCollectionAspectTest.java
+++ b/collection-plugins/hibernate/src/test/java/com/springsource/insight/plugin/hibernate/HibernateSessionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HC3PluginRuntimeDescriptor.java
+++ b/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HC3PluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HttpClientDefinitions.java
+++ b/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HttpClientDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HttpClientExecutionCollectionAspect.aj
+++ b/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HttpClientExecutionCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HttpExternalResourceAnalyzer.java
+++ b/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HttpExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HttpPlaceholderMethod.java
+++ b/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HttpPlaceholderMethod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HttpStatusTraceErrorAnalyzer.java
+++ b/collection-plugins/httpclient3/src/main/java/com/springsource/insight/plugin/apache/http/hc3/HttpStatusTraceErrorAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient3/src/test/java/com/springsource/insight/plugin/apache/http/hc3/HttpClientExecutionCollectionAspectTest.java
+++ b/collection-plugins/httpclient3/src/test/java/com/springsource/insight/plugin/apache/http/hc3/HttpClientExecutionCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient3/src/test/java/com/springsource/insight/plugin/apache/http/hc3/HttpExternalResourceAnalyzerTest.java
+++ b/collection-plugins/httpclient3/src/test/java/com/springsource/insight/plugin/apache/http/hc3/HttpExternalResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient3/src/test/java/com/springsource/insight/plugin/apache/http/hc3/HttpPlaceholderMethodTest.java
+++ b/collection-plugins/httpclient3/src/test/java/com/springsource/insight/plugin/apache/http/hc3/HttpPlaceholderMethodTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HC4PluginRuntimeDescriptor.java
+++ b/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HC4PluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HttpClientDefinitions.java
+++ b/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HttpClientDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HttpClientExecutionCollectionAspect.aj
+++ b/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HttpClientExecutionCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HttpExternalResourceAnalyzer.java
+++ b/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HttpExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HttpPlaceholderRequest.java
+++ b/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HttpPlaceholderRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HttpStatusTraceErrorAnalyzer.java
+++ b/collection-plugins/httpclient4/src/main/java/com/springsource/insight/plugin/apache/http/hc4/HttpStatusTraceErrorAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient4/src/test/java/com/springsource/insight/plugin/apache/http/hc4/HttpClientExecutionCollectionAspectTest.java
+++ b/collection-plugins/httpclient4/src/test/java/com/springsource/insight/plugin/apache/http/hc4/HttpClientExecutionCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient4/src/test/java/com/springsource/insight/plugin/apache/http/hc4/HttpExternalResourceAnalyzerTest.java
+++ b/collection-plugins/httpclient4/src/test/java/com/springsource/insight/plugin/apache/http/hc4/HttpExternalResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/httpclient4/src/test/java/com/springsource/insight/plugin/apache/http/hc4/HttpPlaceholderRequestTest.java
+++ b/collection-plugins/httpclient4/src/test/java/com/springsource/insight/plugin/apache/http/hc4/HttpPlaceholderRequestTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsDefinitions.java
+++ b/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsEndPointAnalyzer.java
+++ b/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsExternalResourceAnalyzer.java
+++ b/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsOperationCollectionAspect.aj
+++ b/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsParamType.java
+++ b/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsParamType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsPluginRuntimeDescriptor.java
+++ b/collection-plugins/jax-rs/src/main/java/com/springsource/insight/plugin/jaxrs/JaxrsPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jax-rs/src/test/java/com/springsource/insight/plugin/jaxrs/JaxrsOperationCollectionAspectTest.java
+++ b/collection-plugins/jax-rs/src/test/java/com/springsource/insight/plugin/jaxrs/JaxrsOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jax-rs/src/test/java/com/springsource/insight/plugin/jaxrs/RestServiceDefinitions.java
+++ b/collection-plugins/jax-rs/src/test/java/com/springsource/insight/plugin/jaxrs/RestServiceDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jax-rs/src/test/java/com/springsource/insight/plugin/jaxrs/RestServiceInstance.java
+++ b/collection-plugins/jax-rs/src/test/java/com/springsource/insight/plugin/jaxrs/RestServiceInstance.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/GetNodeOperationCollectionAspect.aj
+++ b/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/GetNodeOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/ItemOperationCollectionAspect.aj
+++ b/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/ItemOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/JCRCollectionUtils.java
+++ b/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/JCRCollectionUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/JCREndPointAnalyzer.java
+++ b/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/JCREndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/JCRPluginRuntimeDescriptor.java
+++ b/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/JCRPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/LoginOperationCollectionAspect.aj
+++ b/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/LoginOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/OperationCollectionTypes.java
+++ b/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/OperationCollectionTypes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/QueryOperationCollectionAspect.aj
+++ b/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/QueryOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/SaveOperationCollectionAspect.aj
+++ b/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/SaveOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/WorkspaceOperationCollectionAspect.aj
+++ b/collection-plugins/jcr/src/main/java/com/springsource/insight/plugin/jcr/WorkspaceOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/test/java/com/springsource/insight/plugin/jcr/GetOperationCollectionAspectTest.java
+++ b/collection-plugins/jcr/src/test/java/com/springsource/insight/plugin/jcr/GetOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/test/java/com/springsource/insight/plugin/jcr/ItemOperationCollectionAspectTest.java
+++ b/collection-plugins/jcr/src/test/java/com/springsource/insight/plugin/jcr/ItemOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/test/java/com/springsource/insight/plugin/jcr/LoginOperationCollectionAspectTest.java
+++ b/collection-plugins/jcr/src/test/java/com/springsource/insight/plugin/jcr/LoginOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/test/java/com/springsource/insight/plugin/jcr/SaveOperationCollectionAspectTest.java
+++ b/collection-plugins/jcr/src/test/java/com/springsource/insight/plugin/jcr/SaveOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/test/java/com/springsource/insight/plugin/jcr/SimpleTests.java
+++ b/collection-plugins/jcr/src/test/java/com/springsource/insight/plugin/jcr/SimpleTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jcr/src/test/resources/repository.xml
+++ b/collection-plugins/jcr/src/test/resources/repository.xml
@@ -7,7 +7,7 @@
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/ConnectionsTracker.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/ConnectionsTracker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/DatabaseJDBCURIAnalyzer.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/DatabaseJDBCURIAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcConnectionCloseOperationCollectionAspect.aj
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcConnectionCloseOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcDriverConnectOperationCollectionAspect.aj
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcDriverConnectOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcDriverExternalResourceAnalyzer.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcDriverExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcOperationExternalResourceAnalyzer.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcOperationExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcOperationFinalizer.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcOperationFinalizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcPreparedStatementOperationCollectionAspect.aj
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcPreparedStatementOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcQueryExternalResourceGenerator.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcQueryExternalResourceGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcRuntimePluginDescriptor.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcRuntimePluginDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcStatementOperationCollectionAspect.aj
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/JdbcStatementOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/SQLFormatter.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/SQLFormatter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/SqlToHtml.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/SqlToHtml.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/TopLevelJdbcOperationFilter.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/TopLevelJdbcOperationFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/WeakKeyHashMap.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/WeakKeyHashMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/AbstractSqlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/AbstractSqlParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/AbstractSqlPatternParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/AbstractSqlPatternParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/DatabaseType.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/DatabaseType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/JdbcUrlMetaData.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/JdbcUrlMetaData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/JdbcUrlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/JdbcUrlParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/SimpleJdbcUrlMetaData.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/SimpleJdbcUrlMetaData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/SimpleSqlUrlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/SimpleSqlUrlParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/SqlParserPattern.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/SqlParserPattern.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/DB2SqlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/DB2SqlParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/DatabaseURL.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/DatabaseURL.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/HsqlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/HsqlParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/HsqlProperties.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/HsqlProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/MssqlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/MssqlParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/MySqlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/MySqlParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/OracleParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/OracleParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/OracleRACParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/OracleRACParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/PostgresSqlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/PostgresSqlParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/SqlFireParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/SqlFireParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/SqlFirePeerParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/SqlFirePeerParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/SybaseSqlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/SybaseSqlParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/AbstractDatabaseJDBCURIAnalyzerTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/AbstractDatabaseJDBCURIAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/ConnectionsTrackerTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/ConnectionsTrackerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/DatabaseJDBCURIAnalyzerTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/DatabaseJDBCURIAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcConnectionCloseOperationCollectionAspectTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcConnectionCloseOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcConnectionOperationCollectionTestSupport.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcConnectionOperationCollectionTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcDriverConnectOperationCollectionAspectTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcDriverConnectOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcOperationFinalizerTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcOperationFinalizerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcPreparedStatementOperationCollectionAspectTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcPreparedStatementOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcQueryExternalResourceGeneratorTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcQueryExternalResourceGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcStatementOperationCollectionAspectTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcStatementOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcStatementOperationCollectionTestSupport.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcStatementOperationCollectionTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcTraceIntegrationTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/JdbcTraceIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/ParamLoggingPreparedStatementTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/ParamLoggingPreparedStatementTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/PoolingConnectionTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/PoolingConnectionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/SQLFormatterTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/SQLFormatterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/SqlToHtmlTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/SqlToHtmlTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/StoredProcedureExample.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/StoredProcedureExample.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/WeakKeyHashMapTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/WeakKeyHashMapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/AbstractConnection.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/AbstractConnection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/AbstractDatabaseMetaData.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/AbstractDatabaseMetaData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/AbstractStatement.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/AbstractStatement.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/jdk16/Jdk16Connection.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/jdk16/Jdk16Connection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/jdk16/Jdk16DatabaseMetaData.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/jdk16/Jdk16DatabaseMetaData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/jdk16/Jdk16PreparedStatementCollectionAspectTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/jdk16/Jdk16PreparedStatementCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/jdk16/Jdk16Statement.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/jdk16/Jdk16Statement.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/jdk16/Jdk16StatementOperationCollectionAspectTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/helpers/jdk16/Jdk16StatementOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/DB2SqlParserTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/DB2SqlParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/HsqlParserTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/HsqlParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/MssqlParserTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/MssqlParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/MySqlParserTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/MySqlParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/OracleParserTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/OracleParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/OracleRACParserTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/OracleRACParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/PostgresSqlParserTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/PostgresSqlParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SimpleSqlUrlParserTestSupport.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SimpleSqlUrlParserTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SqlFireParserTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SqlFireParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SqlFirePeerParserTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SqlFirePeerParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SqlParserTestImpl.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SqlParserTestImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SqlTestEntry.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SqlTestEntry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SybaseSqlParserTest.java
+++ b/collection-plugins/jdbc/src/test/java/com/springsource/insight/plugin/jdbc/parsers/SybaseSqlParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/AbstractJMSCollectionAspect.aj
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/AbstractJMSCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/AbstractJMSMetricsGenerator.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/AbstractJMSMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/AbstractJMSResourceAnalyzer.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/AbstractJMSResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/DeliveryModeType.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/DeliveryModeType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/DestinationType.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/DestinationType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSConsumerCollectionAspect.aj
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSConsumerCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSConsumerResourceAnalyzer.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSConsumerResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSListenerReceiveMetricsGenerator.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSListenerReceiveMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSMessageListenerCollectionAspect.aj
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSMessageListenerCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSMessageListenerResourceAnalyzer.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSMessageListenerResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSPluginOperationType.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSPluginOperationType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSPluginUtils.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSPluginUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSProducerCollectionAspect.aj
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSProducerCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSProducerResourceAnalyzer.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSProducerResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSReceiveMetricsGenerator.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSReceiveMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSSendMetricsGenerator.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JMSSendMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JmsPluginRuntimeDescriptor.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JmsPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JmsTraceSourceAnalyzer.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/JmsTraceSourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/MessageOperationMap.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/MessageOperationMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/MessageType.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/MessageType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/MessageWrapper.java
+++ b/collection-plugins/jms/src/main/java/com/springsource/insight/plugin/jms/MessageWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/AbstractJMSCollectionAspectTestSupport.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/AbstractJMSCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/AbstractJMSMetricsGeneratorTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/AbstractJMSMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/AbstractJMSResourceAnalyzerTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/AbstractJMSResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSConsumerCollectionAspectTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSConsumerCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSConsumerResourceAnalyzerTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSConsumerResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSListenerReceiveMetricsGeneratorTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSListenerReceiveMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSMessageListenerCollectionAspectTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSMessageListenerCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSMessageListenerResourceAnalyzerTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSMessageListenerResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSPluginUtilsTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSPluginUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSProducerCollectionAspectTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSProducerCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSProducerResourceAnalyzerTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSProducerResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSReceiveMetricsGeneratorTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSReceiveMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSSendMetricsGeneratorTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JMSSendMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JmsTraceSourceAnalyzerTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/JmsTraceSourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/MessageOperationMapTest.java
+++ b/collection-plugins/jms/src/test/java/com/springsource/insight/plugin/jms/MessageOperationMapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiBindOperationCollectionAspect.aj
+++ b/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiBindOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiEndpointAnalyzer.java
+++ b/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiEndpointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiLookupOperationCollectionAspect.aj
+++ b/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiLookupOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiOperationCollectionSupport.aj
+++ b/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiOperationCollectionSupport.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiPluginRuntimeDescriptor.java
+++ b/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiResourceCollectionFilter.java
+++ b/collection-plugins/jndi/src/main/java/com/springsource/insight/plugin/jndi/JndiResourceCollectionFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jndi/src/test/java/com/springsource/insight/plugin/jndi/JndiBindOperationCollectionAspectTest.java
+++ b/collection-plugins/jndi/src/test/java/com/springsource/insight/plugin/jndi/JndiBindOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jndi/src/test/java/com/springsource/insight/plugin/jndi/JndiLookupOperationCollectionAspectTest.java
+++ b/collection-plugins/jndi/src/test/java/com/springsource/insight/plugin/jndi/JndiLookupOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jndi/src/test/java/com/springsource/insight/plugin/jndi/JndiOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/jndi/src/test/java/com/springsource/insight/plugin/jndi/JndiOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jndi/src/test/java/com/springsource/insight/plugin/jndi/JndiResourceCollectionFilterTest.java
+++ b/collection-plugins/jndi/src/test/java/com/springsource/insight/plugin/jndi/JndiResourceCollectionFilterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jndi/src/test/java/com/springsource/insight/plugin/jndi/JndiTestContext.java
+++ b/collection-plugins/jndi/src/test/java/com/springsource/insight/plugin/jndi/JndiTestContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/EntityTransactionCollectionAspect.aj
+++ b/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/EntityTransactionCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/JpaDefinitions.java
+++ b/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/JpaDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/JpaEntityManagerCollectionAspect.aj
+++ b/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/JpaEntityManagerCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/JpaEntityManagerDomainObjectAspect.aj
+++ b/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/JpaEntityManagerDomainObjectAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/JpaEntityManagerLifecycleAspect.aj
+++ b/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/JpaEntityManagerLifecycleAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/JpaPluginRuntimeDescriptor.java
+++ b/collection-plugins/jpa/src/main/java/com/springsource/insight/plugin/jpa/JpaPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/EntityTransactionCollectionAspectTest.java
+++ b/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/EntityTransactionCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/JpaEntityManagerCollectionTestSupport.java
+++ b/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/JpaEntityManagerCollectionTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/JpaEntityManagerDomainObjectAspectTest.java
+++ b/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/JpaEntityManagerDomainObjectAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/JpaEntityManagerLifecycleAspectTest.java
+++ b/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/JpaEntityManagerLifecycleAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/TestEntity.java
+++ b/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/TestEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/TransactionalJpaEntityManagerDomainAspectTest.java
+++ b/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/TransactionalJpaEntityManagerDomainAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/TransactionalJpaEntityManagerTestSupport.java
+++ b/collection-plugins/jpa/src/test/java/com/springsource/insight/plugin/jpa/TransactionalJpaEntityManagerTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/JtaDefinitions.java
+++ b/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/JtaDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/JtaOperationCollectionAspect.aj
+++ b/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/JtaOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/JtaPluginRuntimeDescriptor.java
+++ b/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/JtaPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/TransactionManagerOperationCollectionAspect.aj
+++ b/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/TransactionManagerOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/TransactionOperationCollectionAspect.aj
+++ b/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/TransactionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/UserTransactionOperationCollectionAspect.aj
+++ b/collection-plugins/jta/src/main/java/com/springsource/insight/plugin/jta/UserTransactionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jta/src/test/java/com/springsource/insight/plugin/jta/JtaOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/jta/src/test/java/com/springsource/insight/plugin/jta/JtaOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jta/src/test/java/com/springsource/insight/plugin/jta/TransactionManagerOperationCollectionAspectTest.java
+++ b/collection-plugins/jta/src/test/java/com/springsource/insight/plugin/jta/TransactionManagerOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jta/src/test/java/com/springsource/insight/plugin/jta/TransactionOperationCollectionAspectTest.java
+++ b/collection-plugins/jta/src/test/java/com/springsource/insight/plugin/jta/TransactionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jta/src/test/java/com/springsource/insight/plugin/jta/UserTransactionOperationCollectionAspectTest.java
+++ b/collection-plugins/jta/src/test/java/com/springsource/insight/plugin/jta/UserTransactionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jws/src/main/java/com/springsource/insight/plugin/jws/EndpointMethodOperationCollectionAspect.aj
+++ b/collection-plugins/jws/src/main/java/com/springsource/insight/plugin/jws/EndpointMethodOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jws/src/main/java/com/springsource/insight/plugin/jws/JwsDefinitions.java
+++ b/collection-plugins/jws/src/main/java/com/springsource/insight/plugin/jws/JwsDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jws/src/main/java/com/springsource/insight/plugin/jws/JwsEndPointAnalyzer.java
+++ b/collection-plugins/jws/src/main/java/com/springsource/insight/plugin/jws/JwsEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jws/src/main/java/com/springsource/insight/plugin/jws/JwsOperationCollectionAspect.aj
+++ b/collection-plugins/jws/src/main/java/com/springsource/insight/plugin/jws/JwsOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jws/src/main/java/com/springsource/insight/plugin/jws/JwsPluginRuntimeDescriptor.java
+++ b/collection-plugins/jws/src/main/java/com/springsource/insight/plugin/jws/JwsPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jws/src/test/java/com/springsource/insight/plugin/jws/EndpointMethodOperationCollectionAspectTest.java
+++ b/collection-plugins/jws/src/test/java/com/springsource/insight/plugin/jws/EndpointMethodOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jws/src/test/java/com/springsource/insight/plugin/jws/JwsOperationCollectionAspectTest.java
+++ b/collection-plugins/jws/src/test/java/com/springsource/insight/plugin/jws/JwsOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jws/src/test/java/com/springsource/insight/plugin/jws/JwsServiceDefinitions.java
+++ b/collection-plugins/jws/src/test/java/com/springsource/insight/plugin/jws/JwsServiceDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/jws/src/test/java/com/springsource/insight/plugin/jws/JwsServiceInstance.java
+++ b/collection-plugins/jws/src/test/java/com/springsource/insight/plugin/jws/JwsServiceInstance.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ldap/src/main/java/com/springsource/insight/plugin/ldap/DirContextSearchCollectionAspect.aj
+++ b/collection-plugins/ldap/src/main/java/com/springsource/insight/plugin/ldap/DirContextSearchCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ldap/src/main/java/com/springsource/insight/plugin/ldap/LdapDefinitions.java
+++ b/collection-plugins/ldap/src/main/java/com/springsource/insight/plugin/ldap/LdapDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ldap/src/main/java/com/springsource/insight/plugin/ldap/LdapExternalResourceAnalyzer.java
+++ b/collection-plugins/ldap/src/main/java/com/springsource/insight/plugin/ldap/LdapExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ldap/src/main/java/com/springsource/insight/plugin/ldap/LdapOperationCollectionAspectSupport.aj
+++ b/collection-plugins/ldap/src/main/java/com/springsource/insight/plugin/ldap/LdapOperationCollectionAspectSupport.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ldap/src/main/java/com/springsource/insight/plugin/ldap/LdapPluginRuntimeDescriptor.java
+++ b/collection-plugins/ldap/src/main/java/com/springsource/insight/plugin/ldap/LdapPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ldap/src/test/java/com/springsource/insight/plugin/ldap/DirContextCreator.java
+++ b/collection-plugins/ldap/src/test/java/com/springsource/insight/plugin/ldap/DirContextCreator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ldap/src/test/java/com/springsource/insight/plugin/ldap/DirContextSearchCollectionAspectTest.java
+++ b/collection-plugins/ldap/src/test/java/com/springsource/insight/plugin/ldap/DirContextSearchCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ldap/src/test/java/com/springsource/insight/plugin/ldap/LdapOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/ldap/src/test/java/com/springsource/insight/plugin/ldap/LdapOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/ldap/src/test/java/com/springsource/insight/plugin/ldap/TestLdapContext.java
+++ b/collection-plugins/ldap/src/test/java/com/springsource/insight/plugin/ldap/TestLdapContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/CommonsLoggingOperationCollectionAspect.aj
+++ b/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/CommonsLoggingOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/Log4jLoggingOperationCollectionAspect.aj
+++ b/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/Log4jLoggingOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/LoggingDefinitions.java
+++ b/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/LoggingDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/LoggingMethodOperationCollectionAspect.aj
+++ b/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/LoggingMethodOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/LoggingPluginRuntimeDescriptor.java
+++ b/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/LoggingPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/LoggingTraceErrorAnalyzer.java
+++ b/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/LoggingTraceErrorAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/Slf4jLoggingOperationCollectionAspect.aj
+++ b/collection-plugins/logging/src/main/java/com/springsource/insight/plugin/logging/Slf4jLoggingOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/logging/src/test/java/com/springsource/insight/plugin/logging/CommonsLoggingOperationCollectionAspectTest.java
+++ b/collection-plugins/logging/src/test/java/com/springsource/insight/plugin/logging/CommonsLoggingOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/logging/src/test/java/com/springsource/insight/plugin/logging/Log4jLoggingOperationCollectionAspectTest.java
+++ b/collection-plugins/logging/src/test/java/com/springsource/insight/plugin/logging/Log4jLoggingOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/logging/src/test/java/com/springsource/insight/plugin/logging/LoggingMethodOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/logging/src/test/java/com/springsource/insight/plugin/logging/LoggingMethodOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/logging/src/test/java/com/springsource/insight/plugin/logging/Slf4jLoggingOperationCollectionAspectTest.java
+++ b/collection-plugins/logging/src/test/java/com/springsource/insight/plugin/logging/Slf4jLoggingOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/JavaMailSenderOperationCollectionAspect.aj
+++ b/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/JavaMailSenderOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MailDefinitions.java
+++ b/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MailDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MailOperationCollectionSupport.aj
+++ b/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MailOperationCollectionSupport.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MailPluginRuntimeDescriptor.java
+++ b/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MailPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MailSendExternalResourceAnalyzer.java
+++ b/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MailSendExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MailSendMetricsGenerator.java
+++ b/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MailSendMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MessageSendOperationCollectionAspect.aj
+++ b/collection-plugins/mail/src/main/java/com/springsource/insight/plugin/mail/MessageSendOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mail/src/test/java/com/springsource/insight/plugin/mail/JavaMailSenderOperationCollectionAspectTest.java
+++ b/collection-plugins/mail/src/test/java/com/springsource/insight/plugin/mail/JavaMailSenderOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mail/src/test/java/com/springsource/insight/plugin/mail/MailMetricsGeneratorTest.java
+++ b/collection-plugins/mail/src/test/java/com/springsource/insight/plugin/mail/MailMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mail/src/test/java/com/springsource/insight/plugin/mail/MailResourceAnalyzerTest.java
+++ b/collection-plugins/mail/src/test/java/com/springsource/insight/plugin/mail/MailResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mail/src/test/java/com/springsource/insight/plugin/mail/MessageSendOperationCollectionAspectTest.java
+++ b/collection-plugins/mail/src/test/java/com/springsource/insight/plugin/mail/MessageSendOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/AbstractMongoDBExternalResourceAnalyzer.java
+++ b/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/AbstractMongoDBExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoArgumentUtils.java
+++ b/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoArgumentUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoCollectionOperationCollectionAspect.aj
+++ b/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoCollectionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoCursorOperationCollectionAspect.aj
+++ b/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoCursorOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoDBCollectionExternalResourceAnalyzer.java
+++ b/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoDBCollectionExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoDBOperationExternalResourceAnalyzer.java
+++ b/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoDBOperationExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoDBPluginRuntimeDescriptor.java
+++ b/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoDBPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoDbOperationCollectionAspect.aj
+++ b/collection-plugins/mongodb/src/main/java/com/springsource/insight/plugin/mongodb/MongoDbOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/test/java/com/mongodb/DBCollectionDummy.java
+++ b/collection-plugins/mongodb/src/test/java/com/mongodb/DBCollectionDummy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/AbstractMongoDBAnalyzerTest.java
+++ b/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/AbstractMongoDBAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/DBCursorDummy.java
+++ b/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/DBCursorDummy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/DBDummy.java
+++ b/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/DBDummy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoArgumentUtilsTest.java
+++ b/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoArgumentUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoCollectionOperationCollectionAspectTest.java
+++ b/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoCollectionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoCursorOperationCollectionAspectTest.java
+++ b/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoCursorOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoDBCollectionOperationAnalyzerTest.java
+++ b/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoDBCollectionOperationAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoDBOperationAnalyzerTest.java
+++ b/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoDBOperationAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoDbOperationCollectionAspectTest.java
+++ b/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/MongoDbOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/OperationFTLTest.java
+++ b/collection-plugins/mongodb/src/test/java/com/springsource/insight/plugin/mongodb/OperationFTLTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/ActionOperationCollectionAspect.aj
+++ b/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/ActionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/EventOperationCollectionAspect.aj
+++ b/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/EventOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/GenericOperationCollectionAspect.aj
+++ b/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/GenericOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/OperationCollectionTypes.java
+++ b/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/OperationCollectionTypes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/PortletEndPointAnalyzer.java
+++ b/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/PortletEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/PortletPluginRuntimeDescriptor.java
+++ b/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/PortletPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/RenderOperationCollectionAspect.aj
+++ b/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/RenderOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/ResourceOperationCollectionAspect.aj
+++ b/collection-plugins/portlet/src/main/java/com/springsource/insight/plugin/portlet/ResourceOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/test/java/com/springsource/insight/plugin/portlet/ActionOperationCollectionAspectTest.java
+++ b/collection-plugins/portlet/src/test/java/com/springsource/insight/plugin/portlet/ActionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/test/java/com/springsource/insight/plugin/portlet/ExamplePortlet.java
+++ b/collection-plugins/portlet/src/test/java/com/springsource/insight/plugin/portlet/ExamplePortlet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/test/java/com/springsource/insight/plugin/portlet/ExamplePortletTester.java
+++ b/collection-plugins/portlet/src/test/java/com/springsource/insight/plugin/portlet/ExamplePortletTester.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/test/java/com/springsource/insight/plugin/portlet/GenericOperationCollectionTestSupport.java
+++ b/collection-plugins/portlet/src/test/java/com/springsource/insight/plugin/portlet/GenericOperationCollectionTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/portlet/src/test/java/com/springsource/insight/plugin/portlet/RenderOperationCollectionAspectTest.java
+++ b/collection-plugins/portlet/src/test/java/com/springsource/insight/plugin/portlet/RenderOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/AbstractQuartzValueAccessor.java
+++ b/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/AbstractQuartzValueAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzJobDetailValueAccessor.java
+++ b/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzJobDetailValueAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzJobExecutionContextValueAccessor.java
+++ b/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzJobExecutionContextValueAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzKeyValueAccessor.java
+++ b/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzKeyValueAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzPluginRuntimeDescriptor.java
+++ b/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzSchedulerDefinitions.java
+++ b/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzSchedulerDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzSchedulerEndPointAnalyzer.java
+++ b/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzSchedulerEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzSchedulerOperationCollectionAspect.aj
+++ b/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzSchedulerOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzTraceSourceAnalyzer.java
+++ b/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzTraceSourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzTriggerValueAccessor.java
+++ b/collection-plugins/quartz/src/main/java/com/springsource/insight/plugin/quartz/scheduler/QuartzTriggerValueAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/test/java/com/springsource/insight/plugin/quartz/scheduler/QuartzSchedulerMockJob.java
+++ b/collection-plugins/quartz/src/test/java/com/springsource/insight/plugin/quartz/scheduler/QuartzSchedulerMockJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/test/java/com/springsource/insight/plugin/quartz/scheduler/QuartzSchedulerOperationCollectionAspectTest.java
+++ b/collection-plugins/quartz/src/test/java/com/springsource/insight/plugin/quartz/scheduler/QuartzSchedulerOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/quartz/src/test/java/com/springsource/insight/plugin/quartz/scheduler/QuartzTraceSourceAnalyzerTest.java
+++ b/collection-plugins/quartz/src/test/java/com/springsource/insight/plugin/quartz/scheduler/QuartzTraceSourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMQCollectionAspect.java
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMQCollectionAspect.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMQResourceAnalyzer.java
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMQResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMetricsGenerator.java
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerCollectionAspect.aj
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerMetricsGenerator.java
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerResourceAnalyzer.java
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPluginRuntimeDescriptor.java
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishCollectionAspect.aj
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishMetricsGenerator.java
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishResourceAnalyzer.java
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitPluginOperationType.java
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitPluginOperationType.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitTraceSourceAnalyzer.java
+++ b/collection-plugins/rabbitmq-client/src/main/java/com/springsource/insight/plugin/rabbitmqClient/RabbitTraceSourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMQCollectionAspectTestSupport.java
+++ b/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMQCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMQMetricsGeneratorTest.java
+++ b/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMQMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMQResourceAnalyzerTest.java
+++ b/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/AbstractRabbitMQResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerCollectionAspectTest.java
+++ b/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerMetricsGeneratorTest.java
+++ b/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerResourceAnalyzerTest.java
+++ b/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQConsumerResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishCollectionAspectTest.java
+++ b/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishMetricsGeneratorTest.java
+++ b/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishResourceAnalyzerTest.java
+++ b/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitMQPublishResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitTraceSourceAnalyzerTest.java
+++ b/collection-plugins/rabbitmq-client/src/test/java/com/springsource/insight/plugin/rabbitmqClient/RabbitTraceSourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisClientAspect.aj
+++ b/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisClientAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisCollectionOperationAspect.aj
+++ b/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisCollectionOperationAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisConnectionFactoryOperationCollectionAspect.aj
+++ b/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisConnectionFactoryOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisExternalResourceAnalyzer.java
+++ b/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisMapOperationCollectionAspect.aj
+++ b/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisMapOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisPluginRuntimeDescriptor.java
+++ b/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/RedisPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/util/RedisUtil.java
+++ b/collection-plugins/redis/src/main/java/com/springsource/insight/plugin/redis/util/RedisUtil.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/DummyAbstractRedisCollection.java
+++ b/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/DummyAbstractRedisCollection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/DummyJedisCommands.java
+++ b/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/DummyJedisCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/DummyRedisMapImpl.java
+++ b/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/DummyRedisMapImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/RedisClientAspectTest.java
+++ b/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/RedisClientAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/RedisCollectionOperationAspectTest.java
+++ b/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/RedisCollectionOperationAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/RedisExternalResourceAnalyzerTest.java
+++ b/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/RedisExternalResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/RedisMapOperationCollectionAspectTest.java
+++ b/collection-plugins/redis/src/test/java/com/springsource/insight/plugin/redis/RedisMapOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rmi/src/main/java/com/springsource/insight/plugin/rmi/RmiDefinitions.java
+++ b/collection-plugins/rmi/src/main/java/com/springsource/insight/plugin/rmi/RmiDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rmi/src/main/java/com/springsource/insight/plugin/rmi/RmiListOperationCollectionAspect.aj
+++ b/collection-plugins/rmi/src/main/java/com/springsource/insight/plugin/rmi/RmiListOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rmi/src/main/java/com/springsource/insight/plugin/rmi/RmiOperationCollectionAspect.aj
+++ b/collection-plugins/rmi/src/main/java/com/springsource/insight/plugin/rmi/RmiOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rmi/src/main/java/com/springsource/insight/plugin/rmi/RmiPluginRuntimeDescriptor.java
+++ b/collection-plugins/rmi/src/main/java/com/springsource/insight/plugin/rmi/RmiPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rmi/src/test/java/com/springsource/insight/plugin/rmi/RmiListOperationCollectionAspectTest.java
+++ b/collection-plugins/rmi/src/test/java/com/springsource/insight/plugin/rmi/RmiListOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rmi/src/test/java/com/springsource/insight/plugin/rmi/RmiOperationCollectionAspectTest.java
+++ b/collection-plugins/rmi/src/test/java/com/springsource/insight/plugin/rmi/RmiOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rmi/src/test/java/com/springsource/insight/plugin/rmi/RmiOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/rmi/src/test/java/com/springsource/insight/plugin/rmi/RmiOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/rmi/src/test/java/com/springsource/insight/plugin/rmi/TestRegistry.java
+++ b/collection-plugins/rmi/src/test/java/com/springsource/insight/plugin/rmi/TestRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/DefaultRunnableResolver.java
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/DefaultRunnableResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/ExecuteMethodCollectionAspect.aj
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/ExecuteMethodCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/ExecutorExecuteCollectionAspect.aj
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/ExecutorExecuteCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/ExecutorServiceSubmitCollectionAspect.aj
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/ExecutorServiceSubmitCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/RunExecDefinitions.java
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/RunExecDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/RunExecEndPointAnalyzer.java
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/RunExecEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/RunExecPluginRuntimeDescriptor.java
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/RunExecPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/RunnableResolver.java
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/RunnableResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/RunnableWrapper.java
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/RunnableWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/ScheduledExecutorServiceCollectionAspect.aj
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/ScheduledExecutorServiceCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/SpringAsyncTaskExecutorCollectionAspect.aj
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/SpringAsyncTaskExecutorCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/ThreadStartCollectionAspect.aj
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/ThreadStartCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/TimerTaskScheduleCollectionAspect.aj
+++ b/collection-plugins/run-exec/src/main/java/com/springsource/insight/plugin/runexec/TimerTaskScheduleCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,7 +28,7 @@ import org.aspectj.lang.annotation.SuppressAjWarnings;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/ExecutionCollectionAspectTestSupport.java
+++ b/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/ExecutionCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/ExecutorExecuteCollectionAspectTest.java
+++ b/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/ExecutorExecuteCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/ExecutorServiceSubmitCollectionAspectTest.java
+++ b/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/ExecutorServiceSubmitCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/RunExecEndPointAnalyzerTest.java
+++ b/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/RunExecEndPointAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/ScheduledExecutorServiceCollectionAspectTest.java
+++ b/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/ScheduledExecutorServiceCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/SignallingRunnable.java
+++ b/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/SignallingRunnable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/SpringAsyncTaskExecutorCollectionAspectTest.java
+++ b/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/SpringAsyncTaskExecutorCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/TestExecutor.java
+++ b/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/TestExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/TestRunnable.java
+++ b/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/TestRunnable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/ThreadStartCollectionAspectTest.java
+++ b/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/ThreadStartCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/TimerTaskScheduleCollectionAspectTest.java
+++ b/collection-plugins/run-exec/src/test/java/com/springsource/insight/plugin/runexec/TimerTaskScheduleCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/FilterOperationCollectionAspect.aj
+++ b/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/FilterOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/HttpStatusTraceErrorAnalyzer.java
+++ b/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/HttpStatusTraceErrorAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/HttpTraceSourceAnalyzer.java
+++ b/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/HttpTraceSourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/LifecycleEndPointAnalyzer.java
+++ b/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/LifecycleEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/RequestDispatchEndPointAnalyzer.java
+++ b/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/RequestDispatchEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/RequestResponseSizeMetricsGenerator.java
+++ b/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/RequestResponseSizeMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/ServletContextListenerOperationDestroyedCollectionAspect.aj
+++ b/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/ServletContextListenerOperationDestroyedCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/ServletContextListenerOperationInitializedCollectionAspect.aj
+++ b/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/ServletContextListenerOperationInitializedCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/ServletEndPointAnalyzer.java
+++ b/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/ServletEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/ServletPluginRuntimeDescriptor.java
+++ b/collection-plugins/servlet/src/main/java/com/springsource/insight/plugin/servlet/ServletPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/DummyFilter.java
+++ b/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/DummyFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/ExposedServletPluginSpringBeanTest.java
+++ b/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/ExposedServletPluginSpringBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/FilterOperationCollectionAspectTest.java
+++ b/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/FilterOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/HttpStatusTraceErrorAnalyzerTest.java
+++ b/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/HttpStatusTraceErrorAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/HttpTraceSourceAnalyzerTest.java
+++ b/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/HttpTraceSourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/LifecycleEndPointAnalyzerTest.java
+++ b/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/LifecycleEndPointAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/RequestResponseSizeMetricsGeneratorTest.java
+++ b/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/RequestResponseSizeMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/ServletEndPointAnalyzerTest.java
+++ b/collection-plugins/servlet/src/test/java/com/springsource/insight/plugin/servlet/ServletEndPointAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/HttpURLConnectionOperationCollectionAspect.aj
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/HttpURLConnectionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/ServerSocketChannelAcceptCollectionAspect.aj
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/ServerSocketChannelAcceptCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketAcceptCollectionAspect.aj
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketAcceptCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketAcceptCollectionAspectSupport.aj
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketAcceptCollectionAspectSupport.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketAcceptOperationCollector.java
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketAcceptOperationCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketChannelConnectCollectionAspect.aj
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketChannelConnectCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketCollectOperationContext.java
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketCollectOperationContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketConnectCollectionAspect.aj
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketConnectCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketConnectCollectionAspectSupport.aj
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketConnectCollectionAspectSupport.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketDefinitions.java
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketExternalResourceAnalyzer.java
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketOperationCollectionAspectSupport.aj
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketOperationCollectionAspectSupport.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketPluginRuntimeDescriptor.java
+++ b/collection-plugins/socket/src/main/java/com/springsource/insight/plugin/socket/SocketPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/HttpURLConnectionOperationCollectionAspectTest.java
+++ b/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/HttpURLConnectionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/ServerSocketChannelAcceptCollectionAspectTest.java
+++ b/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/ServerSocketChannelAcceptCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketAcceptCollectionAspectTest.java
+++ b/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketAcceptCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketAcceptCollectionAspectTestSupport.java
+++ b/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketAcceptCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketAcceptorHelper.java
+++ b/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketAcceptorHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketChannelConnectCollectionAspectTest.java
+++ b/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketChannelConnectCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketConnectCollectionAspectTest.java
+++ b/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketConnectCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketConnectCollectionAspectTestSupport.java
+++ b/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketConnectCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketExternalResourceAnalyzerTest.java
+++ b/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketExternalResourceAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/SocketOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/FlowExecutorCollectionAspect.aj
+++ b/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/FlowExecutorCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/FlowOperationCollectionAspect.aj
+++ b/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/FlowOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/JobLauncherCollectionAspect.aj
+++ b/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/JobLauncherCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/JobOperationCollectionAspect.aj
+++ b/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/JobOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/SpringBatchDefinitions.java
+++ b/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/SpringBatchDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/SpringBatchEndPointAnalyzer.java
+++ b/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/SpringBatchEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/SpringBatchOperationCollectionAspect.aj
+++ b/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/SpringBatchOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/SpringBatchPluginRuntimeDescriptor.java
+++ b/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/SpringBatchPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/StepOperationCollectionAspect.aj
+++ b/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/StepOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/TaskletCollectionAspect.aj
+++ b/collection-plugins/spring-batch/src/main/java/com/springsource/insight/plugin/springbatch/TaskletCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/FlowExecutorCollectionAspectTest.java
+++ b/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/FlowExecutorCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/FlowOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/FlowOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/JobLauncherCollectionAspectTest.java
+++ b/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/JobLauncherCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/JobOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/JobOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/SpringBatchOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/SpringBatchOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/StepOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/StepOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/TaskletCollectionAspectTest.java
+++ b/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/TaskletCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/TestDummyJob.java
+++ b/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/TestDummyJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/TestDummyJobRepository.java
+++ b/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/TestDummyJobRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/TestDummyOperationCollector.java
+++ b/collection-plugins/spring-batch/src/test/java/com/springsource/insight/plugin/springbatch/TestDummyOperationCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/ApplicationListenerMethodOperationCollectionAspect.aj
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/ApplicationListenerMethodOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/ClassPathScanOperationCollectionAspect.aj
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/ClassPathScanOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/ComponentMethodOperationCollectionAspect.aj
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/ComponentMethodOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/EventPublisingOperationCollectionAspect.aj
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/EventPublisingOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/InitializingBeanOperationCollectionAspect.aj
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/InitializingBeanOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/RepositoryMethodOperationCollectionAspect.aj
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/RepositoryMethodOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/ServiceMethodOperationCollectionAspect.aj
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/ServiceMethodOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/SpringCoreOperationCollectionAspect.aj
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/SpringCoreOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/SpringCorePluginRuntimeDescriptor.java
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/SpringCorePluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/SpringEventReferenceCollectionAspect.aj
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/SpringEventReferenceCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/SpringLifecycleMethodEndPointAnalyzer.java
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/SpringLifecycleMethodEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/SpringLifecycleMethodOperationCollectionAspect.aj
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/SpringLifecycleMethodOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/StereotypedSpringBeanMethodOperationCollectionAspectSupport.aj
+++ b/collection-plugins/spring-core/src/main/java/com/springsource/insight/plugin/springcore/StereotypedSpringBeanMethodOperationCollectionAspectSupport.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/foo/example/AbstractBean.java
+++ b/collection-plugins/spring-core/src/test/java/com/foo/example/AbstractBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/foo/example/ExampleComponent.java
+++ b/collection-plugins/spring-core/src/test/java/com/foo/example/ExampleComponent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/foo/example/ExampleRepository.java
+++ b/collection-plugins/spring-core/src/test/java/com/foo/example/ExampleRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/foo/example/ExampleService.java
+++ b/collection-plugins/spring-core/src/test/java/com/foo/example/ExampleService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/ApplicationListenerMethodOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/ApplicationListenerMethodOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/ClassPathScanOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/ClassPathScanOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/ComponentMethodOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/ComponentMethodOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/EventPublisingOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/EventPublisingOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/ExposedSpringCorePluginSpringBeanTest.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/ExposedSpringCorePluginSpringBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/InitializingBeanOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/InitializingBeanOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/RepositoryMethodOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/RepositoryMethodOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/ServiceMethodOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/ServiceMethodOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/SpringEventReferenceCollectionAspectTest.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/SpringEventReferenceCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/StereotypeOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/StereotypeOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/beans/Fubar.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/beans/Fubar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/beans/InsightComponent.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/beans/InsightComponent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/beans/InsightRepository.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/beans/InsightRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/beans/InsightService.java
+++ b/collection-plugins/spring-core/src/test/java/com/springsource/insight/plugin/springcore/beans/InsightService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyApplicationEventMulticaster.java
+++ b/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyApplicationEventMulticaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyApplicationEventPublisher.java
+++ b/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyApplicationEventPublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyApplicationListener.java
+++ b/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyApplicationListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyApplicationListenerAndRepository.java
+++ b/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyApplicationListenerAndRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyEvent.java
+++ b/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyEventHolder.java
+++ b/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyEventHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyEventSource.java
+++ b/collection-plugins/spring-core/src/test/java/il/co/springsource/insight/MyEventSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-data/src/main/java/com/springsource/insight/plugin/springdata/RepositoryMethodEndPointAnalyzer.java
+++ b/collection-plugins/spring-data/src/main/java/com/springsource/insight/plugin/springdata/RepositoryMethodEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-data/src/main/java/com/springsource/insight/plugin/springdata/RepositoryMethodOperationCollectionAspect.aj
+++ b/collection-plugins/spring-data/src/main/java/com/springsource/insight/plugin/springdata/RepositoryMethodOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-data/src/main/java/com/springsource/insight/plugin/springdata/SpringDataDefinitions.java
+++ b/collection-plugins/spring-data/src/main/java/com/springsource/insight/plugin/springdata/SpringDataDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-data/src/main/java/com/springsource/insight/plugin/springdata/SpringDataPluginRuntimeDescriptor.java
+++ b/collection-plugins/spring-data/src/main/java/com/springsource/insight/plugin/springdata/SpringDataPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-data/src/test/java/com/springsource/insight/plugin/springdata/JpaRepositoryCollectionAspectTest.java
+++ b/collection-plugins/spring-data/src/test/java/com/springsource/insight/plugin/springdata/JpaRepositoryCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-data/src/test/java/com/springsource/insight/plugin/springdata/RepositoryMethodOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/spring-data/src/test/java/com/springsource/insight/plugin/springdata/RepositoryMethodOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-data/src/test/java/com/springsource/insight/plugin/springdata/dao/TestEntityRepository.java
+++ b/collection-plugins/spring-data/src/test/java/com/springsource/insight/plugin/springdata/dao/TestEntityRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-data/src/test/java/com/springsource/insight/plugin/springdata/model/TestEntity.java
+++ b/collection-plugins/spring-data/src/test/java/com/springsource/insight/plugin/springdata/model/TestEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/AbstractIntegrationOperationCollectionAspect.aj
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/AbstractIntegrationOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/IntegrationEndPointAnalyzer.java
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/IntegrationEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/IntegrationOperationCollectionAspect.aj
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/IntegrationOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/IntegrationPluginRuntimeDescriptor.java
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/IntegrationPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/MessageListenerProps.java
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/MessageListenerProps.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/SpringIntegrationDefinitions.java
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/SpringIntegrationDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/amqp/AmqpInboundChannelAdapterMessageListenerProps.aj
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/amqp/AmqpInboundChannelAdapterMessageListenerProps.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/amqp/MessageListenerOperationCollectionAspect.aj
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/amqp/MessageListenerOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/GatewayMethodInboundMessageMapperAspect.aj
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/GatewayMethodInboundMessageMapperAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/GatewayOperationCollectionAspect.aj
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/GatewayOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/HasMethod.java
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/HasMethod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/HasMethodAspect.aj
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/HasMethodAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/HasRequestMapper.java
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/HasRequestMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/HasRequestMapperAspect.aj
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/HasRequestMapperAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/InboundMessageMapperAspect.aj
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/gateway/InboundMessageMapperAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionExternalResourceAnalyzer.java
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollectionAspect.aj
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollector.java
+++ b/collection-plugins/spring-integration/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/ExposedIntegrationPluginSpringBeanTest.java
+++ b/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/ExposedIntegrationPluginSpringBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/IntegrationEndPointAnalyzerTest.java
+++ b/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/IntegrationEndPointAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/IntegrationOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/IntegrationOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/IntegrationOperationViewTest.java
+++ b/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/IntegrationOperationViewTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/gateway/GatewayMethodInboundMessageMapperAspectTest.java
+++ b/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/gateway/GatewayMethodInboundMessageMapperAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/gateway/InboundMessageMapperAspectTest.java
+++ b/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/gateway/InboundMessageMapperAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/tcp/TcpTestConnectionFactory.java
+++ b/collection-plugins/spring-integration/src/test/java/com/springsource/insight/plugin/integration/tcp/TcpTestConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/AbstractIntegrationOperationCollectionAspect.aj
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/AbstractIntegrationOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/IntegrationEndPointAnalyzer.java
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/IntegrationEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/IntegrationOperationCollectionAspect.aj
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/IntegrationOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/IntegrationPluginRuntimeDescriptor.java
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/IntegrationPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/MessageListenerProps.java
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/MessageListenerProps.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/SpringIntegrationDefinitions.java
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/SpringIntegrationDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/amqp/AmqpInboundChannelAdapterMessageListenerProps.aj
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/amqp/AmqpInboundChannelAdapterMessageListenerProps.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/amqp/MessageListenerOperationCollectionAspect.aj
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/amqp/MessageListenerOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/GatewayMethodInboundMessageMapperAspect.aj
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/GatewayMethodInboundMessageMapperAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/GatewayOperationCollectionAspect.aj
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/GatewayOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/HasMethod.java
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/HasMethod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/HasMethodAspect.aj
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/HasMethodAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/HasRequestMapper.java
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/HasRequestMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/HasRequestMapperAspect.aj
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/HasRequestMapperAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/InboundMessageMapperAspect.aj
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/gateway/InboundMessageMapperAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionExternalResourceAnalyzer.java
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollectionAspect.aj
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollector.java
+++ b/collection-plugins/spring-integration2/src/main/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/ExposedIntegrationPluginSpringBeanTest.java
+++ b/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/ExposedIntegrationPluginSpringBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/IntegrationEndPointAnalyzerTest.java
+++ b/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/IntegrationEndPointAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/IntegrationOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/IntegrationOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/IntegrationOperationViewTest.java
+++ b/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/IntegrationOperationViewTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/gateway/GatewayMethodInboundMessageMapperAspectTest.java
+++ b/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/gateway/GatewayMethodInboundMessageMapperAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/gateway/InboundMessageMapperAspectTest.java
+++ b/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/gateway/InboundMessageMapperAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/tcp/TcpConnectionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/tcp/TcpTestConnectionFactory.java
+++ b/collection-plugins/spring-integration2/src/test/java/com/springsource/insight/plugin/integration/tcp/TcpTestConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/FindOperationCollectionAspect.aj
+++ b/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/FindOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/InitOperationCollectionAspect.aj
+++ b/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/InitOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/LookupOperationCollectionAspect.aj
+++ b/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/LookupOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/Neo4jExternalResourceAnalyzer.java
+++ b/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/Neo4jExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/Neo4jPluginRuntimeDescriptor.java
+++ b/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/Neo4jPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/OperationCollectionTypes.java
+++ b/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/OperationCollectionTypes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/QueryOperationCollectionAspect.aj
+++ b/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/QueryOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/TraverseOperationCollectionAspect.aj
+++ b/collection-plugins/spring-neo4j/src/main/java/com/springsource/insight/plugin/neo4j/TraverseOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/AbstractNeo4jCollectionAspectTestSupport.java
+++ b/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/AbstractNeo4jCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/FindOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/FindOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/InitOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/InitOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/LookupOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/LookupOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/Movie.java
+++ b/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/Movie.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/OperationCollectionAspectTests.java
+++ b/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/OperationCollectionAspectTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/QueryOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/QueryOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/TraverseOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-neo4j/src/test/java/com/springsource/insight/plugin/neo4j/TraverseOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/AbstractAuthenticationCollectionAspect.aj
+++ b/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/AbstractAuthenticationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/AuthenticationManagerCollectionAspect.aj
+++ b/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/AuthenticationManagerCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/AuthenticationProviderCollectionAspect.aj
+++ b/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/AuthenticationProviderCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/AuthenticationProviderOperationCollector.java
+++ b/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/AuthenticationProviderOperationCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/ObscuringOperationCollector.java
+++ b/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/ObscuringOperationCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/SpringSecurityDefinitions.java
+++ b/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/SpringSecurityDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/SpringSecurityPluginRuntimeDescriptor.java
+++ b/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/SpringSecurityPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/UserDetailsManagerCollectionAspect.aj
+++ b/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/UserDetailsManagerCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/UserDetailsOperationCollector.java
+++ b/collection-plugins/spring-security/src/main/java/com/springsource/insight/plugin/spring/security/UserDetailsOperationCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/AuthenticationCollectionAspectTestSupport.java
+++ b/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/AuthenticationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/AuthenticationManagerCollectionAspectTest.java
+++ b/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/AuthenticationManagerCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/AuthenticationProviderCollectionAspectTest.java
+++ b/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/AuthenticationProviderCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/AuthenticationProviderCollectionAspectTestProvider.java
+++ b/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/AuthenticationProviderCollectionAspectTestProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/AuthenticationTestManager.java
+++ b/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/AuthenticationTestManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/SpringSecurityCollectionTestSupport.java
+++ b/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/SpringSecurityCollectionTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/TestingUserDetailsManager.java
+++ b/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/TestingUserDetailsManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/UserDetailsManagerCollectionAspectTest.java
+++ b/collection-plugins/spring-security/src/test/java/com/springsource/insight/plugin/spring/security/UserDetailsManagerCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-tx/src/main/java/com/springsource/insight/plugin/springtx/SpringTXPluginRuntimeDescriptor.java
+++ b/collection-plugins/spring-tx/src/main/java/com/springsource/insight/plugin/springtx/SpringTXPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-tx/src/main/java/com/springsource/insight/plugin/springtx/TransactionOperationCollectionAspect.aj
+++ b/collection-plugins/spring-tx/src/main/java/com/springsource/insight/plugin/springtx/TransactionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-tx/src/main/java/com/springsource/insight/plugin/springtx/TransactionOperationFinalizer.java
+++ b/collection-plugins/spring-tx/src/main/java/com/springsource/insight/plugin/springtx/TransactionOperationFinalizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-tx/src/main/java/com/springsource/insight/plugin/springtx/TransactionOperationStatus.java
+++ b/collection-plugins/spring-tx/src/main/java/com/springsource/insight/plugin/springtx/TransactionOperationStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-tx/src/main/java/com/springsource/insight/plugin/springtx/TransactionPointcuts.aj
+++ b/collection-plugins/spring-tx/src/main/java/com/springsource/insight/plugin/springtx/TransactionPointcuts.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-tx/src/test/java/com/springsource/insight/plugin/springtx/TransactionOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-tx/src/test/java/com/springsource/insight/plugin/springtx/TransactionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-tx/src/test/java/com/springsource/insight/plugin/springtx/TransactionOperationFinalizerTest.java
+++ b/collection-plugins/spring-tx/src/test/java/com/springsource/insight/plugin/springtx/TransactionOperationFinalizerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/AbstractSpringWebAspectSupport.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/AbstractSpringWebAspectSupport.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/AbstractSpringWebEndPointAnalyzer.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/AbstractSpringWebEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/SpringWebPluginRuntimeDescriptor.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/SpringWebPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/SpringWebPointcuts.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/SpringWebPointcuts.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/binder/InitBinderOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/binder/InitBinderOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/binder/InitBinderOperationFinalizer.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/binder/InitBinderOperationFinalizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/AbstractControllerOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/AbstractControllerOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/ControllerEndPointAnalyzer.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/ControllerEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/ControllerOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/ControllerOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/ControllerOperationCollector.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/ControllerOperationCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/LegacyControllerOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/LegacyControllerOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/http/ClientHttpRequestCollectionOperationAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/http/ClientHttpRequestCollectionOperationAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/http/ClientHttpRequestExternalResourceAnalyzer.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/http/ClientHttpRequestExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/http/ClientHttpRequestOperationCollector.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/http/ClientHttpRequestOperationCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/http/ClientHttpRequestTraceErrorAnalyzer.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/http/ClientHttpRequestTraceErrorAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/http/SimpleClientHttpRequestFactoryCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/http/SimpleClientHttpRequestFactoryCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/modelattribute/ModelAttributeOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/modelattribute/ModelAttributeOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/modelattribute/ModelAttributeOperationCollector.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/modelattribute/ModelAttributeOperationCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorExternalResourceAnalyzer.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorExternalResourceAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorOperationCollector.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorOperationCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorTraceErrorAnalyzer.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorTraceErrorAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/SimpleHttpInvokerRequestExecutorAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/SimpleHttpInvokerRequestExecutorAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/request/WebRequestOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/request/WebRequestOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestDeleteOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestDeleteOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestExchangeOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestExchangeOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestExecuteOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestExecuteOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestGetOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestGetOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestHeadOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestHeadOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestIndirectOperationCollectionSupport.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestIndirectOperationCollectionSupport.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestOperationCollectionSupport.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestOperationCollectionSupport.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestOptionsOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestOptionsOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestPostOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestPostOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestPutOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/rest/RestPutOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/validation/ValidationEndPointAnalyzer.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/validation/ValidationEndPointAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/validation/ValidationErrorsMetricsGenerator.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/validation/ValidationErrorsMetricsGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/validation/ValidationJoinPointFinalizer.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/validation/ValidationJoinPointFinalizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/validation/ValidationOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/validation/ValidationOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/view/ViewUtils.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/view/ViewUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/view/render/ViewRenderOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/view/render/ViewRenderOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/view/resolver/ViewResolverMetricCollector.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/view/resolver/ViewResolverMetricCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/view/resolver/ViewResolverOperationCollectionAspect.aj
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/view/resolver/ViewResolverOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/ExposedSpringWebPluginSpringBeanTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/ExposedSpringWebPluginSpringBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/binder/InitBinderOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/binder/InitBinderOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/controller/AbstractControllerOperationCollectionAspectTestSupport.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/controller/AbstractControllerOperationCollectionAspectTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/controller/ControllerEndPointAnalyzerTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/controller/ControllerEndPointAnalyzerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/controller/ControllerOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/controller/ControllerOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/controller/LegacyControllerOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/controller/LegacyControllerOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/http/ClientHttpRequestCollectionOperationAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/http/ClientHttpRequestCollectionOperationAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/http/SimpleClientHttpRequestFactoryCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/http/SimpleClientHttpRequestFactoryCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/modelattribute/ModelAttributeOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/modelattribute/ModelAttributeOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestOperationCollectionTestSupport.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestOperationCollectionTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/remoting/SimpleHttpInvokerRequestExecutorAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/remoting/SimpleHttpInvokerRequestExecutorAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/request/WebRequestOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/request/WebRequestOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestDeleteOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestDeleteOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestExchangeOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestExchangeOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestExecuteOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestExecuteOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestGetOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestGetOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestHeadOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestHeadOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestOperationCollectionTestSupport.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestOperationCollectionTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestOptionsOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestOptionsOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestPostOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestPostOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestPutOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestPutOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/validation/ValidationErrorsMetricsGeneratorTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/validation/ValidationErrorsMetricsGeneratorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/validation/ValidationOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/validation/ValidationOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/view/render/ViewRenderOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/view/render/ViewRenderOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/view/resolver/ViewResolverOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/view/resolver/ViewResolverOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/ActionOperationCollectionAspect.aj
+++ b/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/ActionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/OperationCollectionTypes.java
+++ b/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/OperationCollectionTypes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/OperationCollectionUtils.aj
+++ b/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/OperationCollectionUtils.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/StartOperationCollectionAspect.aj
+++ b/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/StartOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/StateOperationCollectionAspect.aj
+++ b/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/StateOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/TransitionOperationCollectionAspect.aj
+++ b/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/TransitionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/WebflowPluginRuntimeDescriptor.java
+++ b/collection-plugins/spring-webflow/src/main/java/com/springsource/insight/plugin/webflow/WebflowPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/test/java/com/springsource/insight/plugin/webflow/ActionOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-webflow/src/test/java/com/springsource/insight/plugin/webflow/ActionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/test/java/com/springsource/insight/plugin/webflow/StartOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-webflow/src/test/java/com/springsource/insight/plugin/webflow/StartOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/test/java/com/springsource/insight/plugin/webflow/StateOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-webflow/src/test/java/com/springsource/insight/plugin/webflow/StateOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/test/java/com/springsource/insight/plugin/webflow/TransitionOperationCollectionAspectTest.java
+++ b/collection-plugins/spring-webflow/src/test/java/com/springsource/insight/plugin/webflow/TransitionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/spring-webflow/src/test/java/com/springsource/insight/plugin/webflow/WebFlowExecutionTest.java
+++ b/collection-plugins/spring-webflow/src/test/java/com/springsource/insight/plugin/webflow/WebFlowExecutionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/ActionOperationCollectionAspect.aj
+++ b/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/ActionOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/InterceptOperationCollectionAspect.aj
+++ b/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/InterceptOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/OperationCollectionTypes.java
+++ b/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/OperationCollectionTypes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/ResultOperationCollectionAspect.aj
+++ b/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/ResultOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/StartOperationCollectionAspect.aj
+++ b/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/StartOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/Struts2PluginRuntimeDescriptor.java
+++ b/collection-plugins/struts2/src/main/java/com/springsource/insight/plugin/struts2/Struts2PluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/ActionOperationCollectionAspectTest.java
+++ b/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/ActionOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/InterceptOperationCollectionAspectTest.java
+++ b/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/InterceptOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/ResultOperationCollectionAspectTest.java
+++ b/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/ResultOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/StartOperationCollectionAspectTest.java
+++ b/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/StartOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/Struts2Tests.java
+++ b/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/Struts2Tests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/test/action/RegisterAction.java
+++ b/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/test/action/RegisterAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/test/action/RegisterValidationAction.java
+++ b/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/test/action/RegisterValidationAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/test/model/Person.java
+++ b/collection-plugins/struts2/src/test/java/com/springsource/insight/plugin/struts2/test/model/Person.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/tomcat/src/main/java/com/springsource/insight/plugin/tomcat/jsp/JspCompilerOperationCollectionAspect.aj
+++ b/collection-plugins/tomcat/src/main/java/com/springsource/insight/plugin/tomcat/jsp/JspCompilerOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/collection-plugins/tomcat/src/main/java/com/springsource/insight/plugin/tomcat/jsp/TomcatPluginRuntimeDescriptor.java
+++ b/collection-plugins/tomcat/src/main/java/com/springsource/insight/plugin/tomcat/jsp/TomcatPluginRuntimeDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/payme-insight-plugin/src/main/java/org/myorg/insight/myplugin/CashMoneyOperationCollectionAspect.aj
+++ b/samples/payme-insight-plugin/src/main/java/org/myorg/insight/myplugin/CashMoneyOperationCollectionAspect.aj
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/payme-insight-plugin/src/test/java/org/myorg/insight/myplugin/CashMoneyOperationCollectionAspectTest.java
+++ b/samples/payme-insight-plugin/src/test/java/org/myorg/insight/myplugin/CashMoneyOperationCollectionAspectTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/payme-insight-plugin/src/test/java/org/myorg/insight/myplugin/CashMoneyOperationViewTest.java
+++ b/samples/payme-insight-plugin/src/test/java/org/myorg/insight/myplugin/CashMoneyOperationViewTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/payme-webapp/src/main/java/com/springsource/insight/samples/payme/FakeAccount.java
+++ b/samples/payme-webapp/src/main/java/com/springsource/insight/samples/payme/FakeAccount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/payme-webapp/src/main/java/com/springsource/insight/samples/payme/PaymentController.java
+++ b/samples/payme-webapp/src/main/java/com/springsource/insight/samples/payme/PaymentController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *         https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 827 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).