### PR TITLE
URL Cleanup

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -7,12 +7,12 @@ Insight is a VMware® Web application that gives you real-time visibility into a
 * Insight DevEdition answers the question: "What just happened?"
 * Insight Operations answers the question: "How does my code perform in production?"
 
-See more at "http://www.springsource.org/insight":http://www.springsource.org/insight
+See more at "https://www.springsource.org/insight":https://www.springsource.org/insight
 
 h2. Installing and Using Plugins
 
 Plugins for different versions of Insight can be downloaded from: 
-  "http://maven.springframework.org/release/com/springsource/insight/plugins/":http://maven.springframework.org/release/com/springsource/insight/plugins/
+  "https://maven.springframework.org/release/com/springsource/insight/plugins/":https://maven.springframework.org/release/com/springsource/insight/plugins/
 
 Plugins must be copied into the "insight/collection-plugins" directory of an Insight Developer Edition and Insight Dashboard/Agent.
 
@@ -24,8 +24,8 @@ h2. Creating a Plugin
 
 h2. Resources
 
-* Checkout our webinar on developing plugins at: http://www.youtube.com/watch?v=YR3CYnryflw
-* Tutorial: http://pubs.vmware.com/vfabric51/index.jsp?topic=/com.vmware.vfabric.tc-server.2.7/devedition/tutorial-plugin.html
+* Checkout our webinar on developing plugins at: https://www.youtube.com/watch?v=YR3CYnryflw
+* Tutorial: https://pubs.vmware.com/vfabric51/index.jsp?topic=/com.vmware.vfabric.tc-server.2.7/devedition/tutorial-plugin.html
 
 h2. Requirements for a Plugin
 

--- a/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/AxonPluginRuntimeDescriptor.java
+++ b/collection-plugins/axon/src/main/java/org/axonframework/insight/plugin/axon/AxonPluginRuntimeDescriptor.java
@@ -53,7 +53,7 @@ public class AxonPluginRuntimeDescriptor extends PluginRuntimeDescriptor {
     
     @Override
     public String getHref(){
-    	return "http://www.axonframework.org/";
+    	return "https://axoniq.io";
     }
 
 }

--- a/collection-plugins/gemfire-light/README.textile
+++ b/collection-plugins/gemfire-light/README.textile
@@ -1,6 +1,6 @@
 h1. GemFire plugin (light) for Spring Insight
 
-Spring Insight runs in the SpringSource tc Server. See http://www.springsource.org/insight for details. This plugin adds instrumentation to for web applications that use GemFire (http://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html) through the GemFire Java driver, which typically works outside the normal ORM flow. 
+Spring Insight runs in the SpringSource tc Server. See https://www.springsource.org/insight for details. This plugin adds instrumentation to for web applications that use GemFire (https://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html) through the GemFire Java driver, which typically works outside the normal ORM flow. 
 
 The light plugin monitors Query API only.
 

--- a/collection-plugins/gemfire/README.textile
+++ b/collection-plugins/gemfire/README.textile
@@ -1,6 +1,6 @@
 h1. GemFire plugin for Spring Insight
 
-Spring Insight runs in the SpringSource tc Server. See http://www.springsource.org/insight for details. This plugin adds instrumentation to for web applications that use GemFire (http://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html) through the GemFire Java driver, which typically works outside the normal ORM flow. 
+Spring Insight runs in the SpringSource tc Server. See https://www.springsource.org/insight for details. This plugin adds instrumentation to for web applications that use GemFire (https://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html) through the GemFire Java driver, which typically works outside the normal ORM flow. 
 
 h2. Compatibility
 

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/DB2SqlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/DB2SqlParser.java
@@ -19,7 +19,7 @@ package com.springsource.insight.plugin.jdbc.parser.parsers;
 import com.springsource.insight.plugin.jdbc.parser.SimpleSqlUrlParser;
 
 /**
- * @see <A HREF="http://www.razorsql.com/docs/help_db2.html">DB2 JDBC Driver and URL information</A>
+ * @see <A HREF="https://www.razorsql.com/docs/help_db2.html">DB2 JDBC Driver and URL information</A>
  */
 public class DB2SqlParser extends SimpleSqlUrlParser {
 	public static final int	DEFAULT_CONNECTION_PORT=6789;

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/MySqlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/MySqlParser.java
@@ -19,7 +19,7 @@ import com.springsource.insight.plugin.jdbc.parser.AbstractSqlPatternParser;
 
 /**
  * taken from
- * http://dev.mysql.com/doc/refman/5.0/en/connector-j-reference-configuration
+ * https://dev.mysql.com/doc/refman/5.0/en/connector-j-reference-configuration
  * -properties.html
  * 
  * jdbc:mysql://[host][,failoverhost...][:port]/[database] »

--- a/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/SybaseSqlParser.java
+++ b/collection-plugins/jdbc/src/main/java/com/springsource/insight/plugin/jdbc/parser/parsers/SybaseSqlParser.java
@@ -26,7 +26,7 @@ import com.springsource.insight.util.ArrayUtil;
 import com.springsource.insight.util.StringUtil;
 
 /**
- * @see <A HREF="http://www.razorsql.com/docs/help_sybase.html">Sybase JDBC Driver and URL Information</A>
+ * @see <A HREF="https://www.razorsql.com/docs/help_sybase.html">Sybase JDBC Driver and URL Information</A>
  */
 public class SybaseSqlParser extends AbstractSqlParser {
 	public static final String	VENDOR="sybase", SUB_TYPE="Tds";

--- a/collection-plugins/jws/src/test/java/com/springsource/insight/plugin/jws/JwsServiceDefinitions.java
+++ b/collection-plugins/jws/src/test/java/com/springsource/insight/plugin/jws/JwsServiceDefinitions.java
@@ -29,7 +29,7 @@ public final class JwsServiceDefinitions {
     public static final String  SERVICE_NAME="JwsServiceTest",
                                 ENDPOINT=SERVICE_NAME + "Endpoint",
                                 PORT_NAME=SERVICE_NAME + "PortName",
-                                TARGET_NAMESPACE="http://lu.ci.an.demo/" + SERVICE_NAME,
+                                TARGET_NAMESPACE="https://lu.ci.an.demo/" + SERVICE_NAME,
                                 WSDL_LOCATION="WEB-INF/wsdl/" + SERVICE_NAME + ".wsdl";
 
     // constants used by the WebMethod/WebParam annotation(s)

--- a/collection-plugins/mongodb/README.textile
+++ b/collection-plugins/mongodb/README.textile
@@ -1,6 +1,6 @@
 h1. MongoDB plugin for Spring Insight
 
-Spring Insight runs in the SpringSource tc Server. See http://www.springsource.org/insight for details. This plugin adds instrumentation to for web applications that use MongoDB (http://www.mongodb.org) through the MongoDB Java driver, which typically works outside the normal ORM flow. 
+Spring Insight runs in the SpringSource tc Server. See https://www.springsource.org/insight for details. This plugin adds instrumentation to for web applications that use MongoDB (https://www.mongodb.org) through the MongoDB Java driver, which typically works outside the normal ORM flow. 
 
 h2. What does it do?
 

--- a/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/HttpURLConnectionOperationCollectionAspectTest.java
+++ b/collection-plugins/socket/src/test/java/com/springsource/insight/plugin/socket/HttpURLConnectionOperationCollectionAspectTest.java
@@ -117,7 +117,7 @@ extends SocketOperationCollectionAspectTestSupport {
                 continue;	// this is a response header and we do not intercept them
             }
 
-            // see http://stackoverflow.com/questions/2864062/getrequestpropertyauthorization-always-returns-null
+            // see https://stackoverflow.com/questions/2864062/getrequestpropertyauthorization-always-returns-null
             List<String>	values=propsMap.get(hdrName);
             if (ListUtil.size(values) <= 0) {
                 continue;
@@ -150,7 +150,7 @@ extends SocketOperationCollectionAspectTestSupport {
         assertObscureTestResults(marker, hdrName, "X-Dummy-Value", false);
 
         for (String defName : HttpObfuscator.DEFAULT_OBFUSCATED_HEADERS_LIST) {
-            // see http://stackoverflow.com/questions/2864062/getrequestpropertyauthorization-always-returns-null
+            // see https://stackoverflow.com/questions/2864062/getrequestpropertyauthorization-always-returns-null
             List<String>	values=propsMap.get(defName);
             if (ListUtil.size(values) <= 0) {
                 continue;

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/ControllerOperationCollector.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/controller/ControllerOperationCollector.java
@@ -36,8 +36,8 @@ import com.springsource.insight.util.StringUtil;
 /**
  * Renders any {@link Map}, {@link Model}, {@link View}, {@link ModelMap}
  * and/or {@link ModelAndView} attributes
- * @see <A HREF="http://static.springsource.org/spring/docs/3.1.x/spring-framework-reference/html/mvc.html#mvc-ann-arguments">Supported method argument types</A>
- * @see <A HREF="http://static.springsource.org/spring/docs/3.1.x/spring-framework-reference/html/mvc.html#mvc-ann-return-types">Supported method return types</A>
+ * @see <A HREF="https://docs.spring.io/spring/docs/3.1.x/spring-framework-reference/html/mvc.html#mvc-ann-arguments">Supported method argument types</A>
+ * @see <A HREF="https://docs.spring.io/spring/docs/3.1.x/spring-framework-reference/html/mvc.html#mvc-ann-return-types">Supported method return types</A>
  */
 public class ControllerOperationCollector extends DefaultOperationCollector {
     private static final InterceptConfiguration configuration = InterceptConfiguration.getInstance();

--- a/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorExternalResourceAnalyzer.java
+++ b/collection-plugins/spring-web/src/main/java/com/springsource/insight/plugin/springweb/remoting/HttpInvokerRequestExecutorExternalResourceAnalyzer.java
@@ -46,7 +46,7 @@ public class HttpInvokerRequestExecutorExternalResourceAnalyzer extends Abstract
      * Special attribute used to indicate whether the HTTP invocation was
      * executed using core Java classes (e.g. {@link java.net.HttpURLConnection}
      * only or via a framework (e.g., <A
-     * HREF="http://hc.apache.org/httpclient-3.x/">Apache client</A>). We
+     * HREF="https://hc.apache.org/httpclient-3.x/">Apache client</A>). We
      * generate an external resource only for the <U>core</U> classes invocation
      * and rely on the other plugins for the alternative frameworks. This is
      * done in order to avoid ambiguity if both the HTTP invoker aspect and the

--- a/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestOperationCollectionTestSupport.java
+++ b/collection-plugins/spring-web/src/test/java/com/springsource/insight/plugin/springweb/rest/RestOperationCollectionTestSupport.java
@@ -61,7 +61,7 @@ public abstract class RestOperationCollectionTestSupport extends OperationCollec
 	}
 
 	protected String createTestURI (String testName) {
-		return "http://37.77.34.7:7365/" + getClass().getSimpleName() + "/" + testName;
+		return "https://37.77.34.7:7365/" + getClass().getSimpleName() + "/" + testName;
 	}
 
 	protected Operation assertRestOperationResult (Object ignored) {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.axonframework.org/ (301) with 1 occurrences migrated to:  
  https://axoniq.io ([https](https://www.axonframework.org/) result SSLHandshakeException).
* [ ] http://37.77.34.7:7365/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://37.77.34.7:7365/ ([https](https://37.77.34.7:7365/) result ConnectTimeoutException).
* [ ] http://lu.ci.an.demo/ (UnknownHostException) with 1 occurrences migrated to:  
  https://lu.ci.an.demo/ ([https](https://lu.ci.an.demo/) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://static.springsource.org/spring/docs/3.1.x/spring-framework-reference/html/mvc.html (301) with 2 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.1.x/spring-framework-reference/html/mvc.html ([https](https://static.springsource.org/spring/docs/3.1.x/spring-framework-reference/html/mvc.html) result 200).
* [ ] http://hc.apache.org/httpclient-3.x/ with 1 occurrences migrated to:  
  https://hc.apache.org/httpclient-3.x/ ([https](https://hc.apache.org/httpclient-3.x/) result 200).
* [ ] http://maven.springframework.org/release/com/springsource/insight/plugins/ with 2 occurrences migrated to:  
  https://maven.springframework.org/release/com/springsource/insight/plugins/ ([https](https://maven.springframework.org/release/com/springsource/insight/plugins/) result 200).
* [ ] http://stackoverflow.com/questions/2864062/getrequestpropertyauthorization-always-returns-null with 2 occurrences migrated to:  
  https://stackoverflow.com/questions/2864062/getrequestpropertyauthorization-always-returns-null ([https](https://stackoverflow.com/questions/2864062/getrequestpropertyauthorization-always-returns-null) result 200).
* [ ] http://www.razorsql.com/docs/help_db2.html with 1 occurrences migrated to:  
  https://www.razorsql.com/docs/help_db2.html ([https](https://www.razorsql.com/docs/help_db2.html) result 200).
* [ ] http://www.razorsql.com/docs/help_sybase.html with 1 occurrences migrated to:  
  https://www.razorsql.com/docs/help_sybase.html ([https](https://www.razorsql.com/docs/help_sybase.html) result 200).
* [ ] http://www.youtube.com/watch?v=YR3CYnryflw with 1 occurrences migrated to:  
  https://www.youtube.com/watch?v=YR3CYnryflw ([https](https://www.youtube.com/watch?v=YR3CYnryflw) result 200).
* [ ] http://dev.mysql.com/doc/refman/5.0/en/connector-j-reference-configuration with 1 occurrences migrated to:  
  https://dev.mysql.com/doc/refman/5.0/en/connector-j-reference-configuration ([https](https://dev.mysql.com/doc/refman/5.0/en/connector-j-reference-configuration) result 301).
* [ ] http://pubs.vmware.com/vfabric51/index.jsp?topic=/com.vmware.vfabric.tc-server.2.7/devedition/tutorial-plugin.html with 1 occurrences migrated to:  
  https://pubs.vmware.com/vfabric51/index.jsp?topic=/com.vmware.vfabric.tc-server.2.7/devedition/tutorial-plugin.html ([https](https://pubs.vmware.com/vfabric51/index.jsp?topic=/com.vmware.vfabric.tc-server.2.7/devedition/tutorial-plugin.html) result 301).
* [ ] http://www.mongodb.org with 1 occurrences migrated to:  
  https://www.mongodb.org ([https](https://www.mongodb.org) result 301).
* [ ] http://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html with 2 occurrences migrated to:  
  https://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html ([https](https://www.vmware.com/products/application-platform/vfabric-gemfire/overview.html) result 301).
* [ ] http://www.springsource.org/insight with 5 occurrences migrated to:  
  https://www.springsource.org/insight ([https](https://www.springsource.org/insight) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1/placeholder with 2 occurrences
* http://goodbye/world with 1 occurrences
* http://hello/world with 1 occurrences
* http://here/testSuccessfulRemoteInvocation with 1 occurrences
* http://java.sun.com/jstl/core with 2 occurrences
* http://java.sun.com/portlet with 3 occurrences
* http://localhost with 5 occurrences
* http://somewhere:7365/ with 1 occurrences
* http://somewhere:7365/testExecutionCollected with 2 occurrences
* http://test-host:3777/testBasicOperatiom with 4 occurrences
* http://there/testFailedRemoteInvocation with 1 occurrences
* http://www.w3.org/2001/XMLSchema with 1 occurrences